### PR TITLE
Add -m option to switch to parse multiple files at once

### DIFF
--- a/rrrocket/src/main.rs
+++ b/rrrocket/src/main.rs
@@ -6,16 +6,17 @@ extern crate structopt;
 #[macro_use]
 extern crate structopt_derive;
 
-use failure::{Error, ResultExt};
+use failure::{err_msg, Error, ResultExt};
 use structopt::StructOpt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter};
 use std::io::prelude::*;
 use rayon::prelude::*;
-use boxcars::{CrcCheck, NetworkParse, ParserBuilder};
+use boxcars::{CrcCheck, NetworkParse, ParserBuilder, Replay};
 
 #[derive(StructOpt, Debug, Clone, PartialEq)]
-#[structopt(name = "rrrocket", about = "Parses Rocket League replay files and writes a .json file with the decoded information")]
+#[structopt(name = "rrrocket",
+            about = "Parses Rocket League replay files and outputs JSON with decoded information")]
 struct Opt {
     #[structopt(short = "c", long = "crc-check", help = "forces a crc check for corruption even when replay was successfully parsed")]
     crc: bool,
@@ -23,6 +24,9 @@ struct Opt {
     #[structopt(short = "n", long = "network-parse", help = "parses the network data of a replay instead of skipping it")]
     body: bool,
 
+    #[structopt(short = "m", long = "multiple", help = "parse multiple replays, instead of writing JSON to stdout, write to a sibling JSON file")]
+    multiple: bool,
+    
     #[structopt(help = "Rocket League replay files")] input: Vec<String>,
 }
 
@@ -35,8 +39,22 @@ fn read_file(input: &str) -> Result<Vec<u8>, Error> {
     Ok(buffer)
 }
 
-fn run() -> Result<(), Error> {
-    let opt = Opt::from_args();
+fn parse_replay<'a>(opt: &Opt, data: &'a [u8]) -> Result<Replay<'a>, Error> {
+    ParserBuilder::new(&data[..])
+        .with_crc_check(if opt.crc {
+            CrcCheck::Always
+        } else {
+            CrcCheck::OnError
+        })
+        .with_network_parse(if opt.body {
+            NetworkParse::Always
+        } else {
+            NetworkParse::Never
+        })
+        .parse()
+}
+
+fn parse_multiple_replays(opt: &Opt) -> Result<(), Error> {
     let res: Result<Vec<()>, Error> = opt.input
         .par_iter()
         .map(|file| {
@@ -54,18 +72,7 @@ fn run() -> Result<(), Error> {
                 })?;
             let mut writer = BufWriter::new(fout);
             let data = read_file(file)?;
-            let replay = ParserBuilder::new(&data[..])
-                .with_crc_check(if opt.crc {
-                    CrcCheck::Always
-                } else {
-                    CrcCheck::OnError
-                })
-                .with_network_parse(if opt.body {
-                    NetworkParse::Always
-                } else {
-                    NetworkParse::Never
-                })
-                .parse()
+            let replay = parse_replay(opt, &data[..])
                 .with_context(|e| format!("Could not parse: {} with error: {}", file, e))?;
             serde_json::to_writer(&mut writer, &replay).with_context(|e| {
                 format!("Could not serialize replay {} to {}: {}", file, outfile, e)
@@ -75,6 +82,23 @@ fn run() -> Result<(), Error> {
         .collect();
     res?;
     Ok(())
+}
+
+fn run() -> Result<(), Error> {
+    let opt = Opt::from_args();
+    if opt.multiple {
+        parse_multiple_replays(&opt)
+    } else if opt.input.len() != 1 {
+        Err(err_msg(
+            "Expected one input file if --multiple is not specified",
+        ))
+    } else {
+        let file = &opt.input[0];
+        let data = read_file(file)?;
+        let replay = parse_replay(&opt, &data[..]).context("Could not parse replay")?;
+        serde_json::to_writer(&mut io::stdout(), &replay).context("Could not serialize replay")?;
+        Ok(())
+    }
 }
 
 fn main() {


### PR DESCRIPTION
Add back to the ability to read a single file and output the JSON to stdout instead of a sibling JSON file.

Closes #14