### PR TITLE
Update 64bit Number Serialization

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -62,6 +62,8 @@ pub enum Attribute {
     Float(f32),
     GameMode(u8, u8),
     Int(i32),
+
+    #[serde(serialize_with = "crate::serde_utils::display_it")]
     Int64(i64),
     Loadout(Loadout),
     TeamLoadout(TeamLoadout),
@@ -69,6 +71,8 @@ pub enum Attribute {
     MusicStinger(MusicStinger),
     PlayerHistoryKey(u16),
     Pickup(Pickup),
+
+    #[serde(serialize_with = "crate::serde_utils::display_it")]
     QWord(u64),
     Welded(Welded),
     Title(bool, bool, u32, u32, u32, u32, u32, bool),
@@ -198,8 +202,12 @@ pub enum RemoteId {
     PlayStation(Vec<u8>),
     PsyNet(Vec<u8>),
     SplitScreen(u32),
+
+    #[serde(serialize_with = "crate::serde_utils::display_it")]
     Steam(u64),
     Switch(Vec<u8>),
+
+    #[serde(serialize_with = "crate::serde_utils::display_it")]
     Xbox(u64),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ mod errors;
 mod models;
 mod network;
 mod parsing;
+mod serde_utils;
 
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
 mod hashes {

--- a/src/models.rs
+++ b/src/models.rs
@@ -86,7 +86,7 @@ pub enum HeaderProp<'a> {
     Float(f32),
     Int(i32),
     Name(Cow<'a, str>),
-    QWord(i64),
+    QWord(u64),
     Str(Cow<'a, str>),
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,3 @@
-use crate::network::Frame;
-use serde::ser::{SerializeMap, SerializeSeq};
 /// # Models
 ///
 /// Here lies the data structures that a rocket league replay is decoded into. All of the models
@@ -10,6 +8,8 @@ use serde::ser::{SerializeMap, SerializeSeq};
 /// numeric/string types). Asking "why JSON" would be next logical step, and that's due to other
 /// rocket league replay parsers (like Octane) using JSON; however, the output of this library is
 /// not compatible with that of other rocket league replay parsers.
+use crate::network::Frame;
+use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -182,7 +182,7 @@ impl<'a> Serialize for HeaderProp<'a> {
             HeaderProp::Byte => serializer.serialize_u8(0),
             HeaderProp::Float(ref x) => serializer.serialize_f32(*x),
             HeaderProp::Int(ref x) => serializer.serialize_i32(*x),
-            HeaderProp::QWord(ref x) => serializer.serialize_i64(*x),
+            HeaderProp::QWord(ref x) => serializer.collect_str(x),
             HeaderProp::Name(ref x) | HeaderProp::Str(ref x) => serializer.serialize_str(x),
         }
     }
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn serialize_header_numbers() {
         assert_eq!(to_json(&HeaderProp::Byte), "0");
-        assert_eq!(to_json(&HeaderProp::QWord(10)), "10");
+        assert_eq!(to_json(&HeaderProp::QWord(10)), "\"10\"");
         assert_eq!(to_json(&HeaderProp::Float(10.2)), "10.2");
         assert_eq!(to_json(&HeaderProp::Int(11)), "11");
     }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1133,7 +1133,7 @@ impl<'a> Parser<'a> {
     }
 
     fn qword_property(&mut self) -> Result<HeaderProp<'a>, ParseError> {
-        self.take(16, |d| HeaderProp::QWord(le_i64(&d[8..])))
+        self.take(16, |d| HeaderProp::QWord(le_u64(&d[8..])))
     }
 
     fn array_property(&mut self) -> Result<HeaderProp<'a>, ParseError> {
@@ -1253,8 +1253,8 @@ fn le_f32(d: &[u8]) -> f32 {
 }
 
 #[inline]
-fn le_i64(d: &[u8]) -> i64 {
-    LittleEndian::read_i64(d)
+fn le_u64(d: &[u8]) -> u64 {
+    LittleEndian::read_u64(d)
 }
 
 #[cfg(test)]

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,0 +1,12 @@
+use serde::Serializer;
+use std::fmt::Display;
+
+/// For the times when the `Display` string is more appropriate than the default serialization
+/// strategy
+pub fn display_it<T, S>(data: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Display,
+    S: Serializer,
+{
+    serializer.collect_str(data)
+}


### PR DESCRIPTION
Javascript numbers are 64bit floating point. 64bit integers can't be represented wholly in floating point notation. Thus serialize them as strings so that downstream applications can decide on how best to interpret large numbers (like 76561198122624102). Affects Int64, QWord, Steam, and XBox attributes.

This PR also changes QWord header property from i64 to u64 as some pointed out that negative numbers didn't make sense for some QWord properties.