### PR TITLE
CRC data moved to unsigned from signed

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 #[derive(Serialize, PartialEq, Debug, Clone)]
 pub struct Replay<'a> {
     pub header_size: i32,
-    pub header_crc: i32,
+    pub header_crc: u32,
     pub major_version: i32,
     pub minor_version: i32,
     pub net_version: Option<i32>,
@@ -29,7 +29,7 @@ pub struct Replay<'a> {
     #[serde(serialize_with = "pair_vec")]
     pub properties: Vec<(&'a str, HeaderProp<'a>)>,
     pub content_size: i32,
-    pub content_crc: i32,
+    pub content_crc: u32,
     pub network_frames: Option<NetworkFrames>,
     pub levels: Vec<Cow<'a, str>>,
     pub keyframes: Vec<KeyFrame>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -219,6 +219,7 @@ impl<'a> Parser<'a> {
         let header_crc = self
             .core
             .take(4, le_i32)
+            .map(|x| x as u32)
             .with_context(|e| self.err_str("header crc", e))?;
 
         let header_data = self
@@ -237,6 +238,7 @@ impl<'a> Parser<'a> {
         let content_crc = self
             .core
             .take(4, le_i32)
+            .map(|x| x as u32)
             .with_context(|e| self.err_str("content crc", e))?;
 
         let content_data = self


### PR DESCRIPTION
A signed checksum doesn't make any sense, as one is mostly interested in
the bits, but seeing a negative sign in serialized json can be
misleading