### PR TITLE
Expose error types as part of public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,23 @@ Serialization support is provided through [serde](https://github.com/serde-rs/se
 Below is an example to output the replay structure to json:
 
 ```rust
+use boxcars::{ParseError, Replay};
+use std::error;
 use std::fs::File;
 use std::io::{self, Read};
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn parse_rl<'a>(data: &'a [u8]) -> Result<Replay<'a>, ParseError> {
+    boxcars::ParserBuilder::new(&data)
+        .on_error_check_crc()
+        .parse()
+}
+
+fn run() -> Result<(), Box<dyn error::Error>> {
     let filename = "assets/replays/good/rumble.replay";
     let mut f = File::open(filename)?;
     let mut buffer = vec![];
     f.read_to_end(&mut buffer)?;
-    let replay = boxcars::ParserBuilder::new(&buffer)
-        .on_error_check_crc()
-        .parse()?;
-
+    let replay = parse_rl(&buffer)?;
     serde_json::to_writer(&mut io::stdout(), &replay)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,26 +27,32 @@
 //! Below is an example to output the replay structure to json:
 //!
 //! ```
+//! use boxcars::{ParseError, Replay};
+//! use std::error;
 //! use std::fs::File;
 //! use std::io::{self, Read};
-//! use std::error::Error;
 //!
 //! # fn main() {
 //! #    let filename = "assets/replays/good/rumble.replay";
 //! #    run(filename).unwrap();
 //! # }
 //!
-//! fn run(filename: &str) -> Result<(), Box<dyn Error>> {
-//! let mut f = File::open(filename)?;
+//! fn parse_rl<'a>(data: &'a [u8]) -> Result<Replay<'a>, ParseError> {
+//!     boxcars::ParserBuilder::new(&data)
+//!         .on_error_check_crc()
+//!         .parse()
+//! }
+//!
+//! fn run(filename: &str) -> Result<(), Box<dyn error::Error>> {
+//!     let filename = "assets/replays/good/rumble.replay";
+//!     let mut f = File::open(filename)?;
 //!     let mut buffer = vec![];
 //!     f.read_to_end(&mut buffer)?;
-//!     let replay = boxcars::ParserBuilder::new(&buffer)
-//!         .on_error_check_crc()
-//!         .parse()?;
-//!
+//!     let replay = parse_rl(&buffer)?;
 //!     serde_json::to_writer(&mut io::stdout(), &replay)?;
 //!     Ok(())
 //! }
+//!
 //! ```
 
 #![recursion_limit = "1000"]
@@ -57,6 +63,7 @@ extern crate if_chain;
 #[macro_use]
 extern crate serde;
 
+pub use self::errors::{AttributeError, NetworkError, ParseError};
 pub use self::models::*;
 pub use self::network::attributes::Attribute;
 pub use self::network::*;


### PR DESCRIPTION
Parsing a replay can return a `ParseError`, but one is unable to query
for more information. It's an opaque type that one can only extract a
string display from. This is limiting to those who want to dive deep
into the errors. For instance, counting errors from corrupt replays vs
errors from a new patch version (eg: `TimeOutOfRange{Update, New}`)