### PR TITLE
Include attribute object id on actor update

### DIFF
--- a/src/network/models.rs
+++ b/src/network/models.rs
@@ -102,6 +102,9 @@ pub struct UpdatedAttribute {
     /// The attribute stream id that was decoded
     pub stream_id: StreamId,
 
+    /// The attribute's object id
+    pub object_id: ObjectId,
+
     /// The actual data from the decoded attribute
     pub attribute: Attribute,
 }


### PR DESCRIPTION
When viewing JSON output for a player name in the network data, one can
see something like this:

```json
{
  "actor_id": 4,
  "stream_id": 34,
  "attribute": {
    "String": "Nadir"
  }
}
```

While it's obvious that the given attribute is a string, the actual
attribute name (in this case "PlayerName") is obscured. Yes technically
it's the `stream_id` but the `stream_id` doesn't map to anything
concrete. One would have to reconstruct the object attribute tree which
is nontrivial. The fix is to include the attribute's object id:

```json
{
  "actor_id": 4,
  "stream_id": 34,
  "object_id": 86,
  "attribute": {
    "String": "Nadir"
  }
}
```

Where `replay.objects[attribute.object_id]` would resolve to "Engine.PlayerReplicationInfo:PlayerName".

Using the above approach the following benchmarks changed:

- 5% increase in serialization time
- Negligible increase in decoding time
- 5% increase in size of serialized json output