### PR TITLE
Overhaul error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ extern crate if_chain;
 #[macro_use]
 extern crate serde;
 
-pub use self::errors::{AttributeError, NetworkError, ParseError};
+pub use self::errors::{AttributeError, FrameError, FrameContext, NetworkError, ParseError};
 pub use self::models::*;
 pub use self::network::attributes::Attribute;
 pub use self::network::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -221,11 +221,11 @@ impl<'a> Parser<'a> {
         let network: Option<NetworkFrames> = match self.network_parse {
             NetworkParse::Always => Some(
                 self.parse_network(&header, &body)
-                    .map_err(ParseError::NetworkError)?,
+                    .map_err(|x| ParseError::NetworkError(Box::new(x)))?,
             ),
             NetworkParse::IgnoreOnError => self
                 .parse_network(&header, &body)
-                .map_err(ParseError::NetworkError)
+                .map_err(|x| ParseError::NetworkError(Box::new(x)))
                 .ok(),
             NetworkParse::Never => None,
         };
@@ -473,10 +473,7 @@ mod tests {
         let data = include_bytes!("../assets/replays/bad/fuzz-string-too-long2.replay");
         let mut parser = Parser::new(&data[..], CrcCheck::Never, NetworkParse::Always);
         let err = parser.parse().unwrap_err();
-        assert_eq!(
-            "Attribute error: Unexpected size for string: -1912602609",
-            format!("{}", err)
-        );
+        assert!(format!("{}", err).contains("Unexpected size for string: -1912602609"));
     }
 
     #[test]

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -1,4 +1,4 @@
-use boxcars::{self, AttributeError, NetworkError, ObjectId, ParseError, ParserBuilder};
+use boxcars::{self, NetworkError, ParseError, ParserBuilder};
 
 #[test]
 fn test_sample1() {
@@ -248,15 +248,10 @@ fn test_error_extraction() {
         _ => panic!("Expecting network error"),
     };
 
-    match ne {
-        NetworkError::ObjectIdOutOfRange(id) => {
-            let new_id: ObjectId = id;
-            assert!(new_id.0 != 0);
+    match *ne {
+        NetworkError::ObjectIdOutOfRange(obj) => {
+            assert!(obj.0 != 0);
         }
-        NetworkError::AttributeError(ae) => match ae {
-            AttributeError::Unimplemented => panic!("Unexpected unimplemented attribute error"),
-            _ => panic!("Unexpected attribute error"),
-        },
-        _ => panic!("Expecting object id out of range"),
+        x => panic!("Expecting object id out of range. not {:?}", x),
     }
 }


### PR DESCRIPTION
Provide much better contextual error messages. Technically this break backwards compatibility, but I can't imagine relying on the previous error structure.