### PR TITLE
Update fuzz suite

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,17 +1,18 @@
-
 [package]
 name = "boxcars-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
+edition = "2018"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies.boxcars]
 path = ".."
-[dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[dependencies]
+libfuzzer-sys = "0.2.1"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/crc-body.rs
+++ b/fuzz/fuzz_targets/crc-body.rs
@@ -1,8 +1,6 @@
 #![no_main]
-extern crate boxcars;
-#[macro_use]
-extern crate libfuzzer_sys;
 
+use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let _ = boxcars::ParserBuilder::new(&data)
         .always_check_crc()

--- a/fuzz/fuzz_targets/crc-no-body.rs
+++ b/fuzz/fuzz_targets/crc-no-body.rs
@@ -1,8 +1,6 @@
 #![no_main]
-extern crate boxcars;
-#[macro_use]
-extern crate libfuzzer_sys;
 
+use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let _ = boxcars::ParserBuilder::new(&data)
         .always_check_crc()

--- a/fuzz/fuzz_targets/no-crc-body.rs
+++ b/fuzz/fuzz_targets/no-crc-body.rs
@@ -1,8 +1,6 @@
 #![no_main]
-extern crate boxcars;
-#[macro_use]
-extern crate libfuzzer_sys;
 
+use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let _ = boxcars::ParserBuilder::new(&data)
         .on_error_check_crc()

--- a/fuzz/fuzz_targets/no-crc-no-body.rs
+++ b/fuzz/fuzz_targets/no-crc-no-body.rs
@@ -1,8 +1,6 @@
 #![no_main]
-extern crate boxcars;
-#[macro_use]
-extern crate libfuzzer_sys;
 
+use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let _ = boxcars::ParserBuilder::new(&data)
         .on_error_check_crc()


### PR DESCRIPTION
- Use released version of libfuzzer
- Use rust 2018 edition