### PR TITLE
Migrate StatEvent to struct with signed object id field

### DIFF
--- a/src/network/attributes.rs
+++ b/src/network/attributes.rs
@@ -95,7 +95,7 @@ pub enum Attribute {
     PrivateMatch(Box<PrivateMatchSettings>),
     LoadoutOnline(Vec<Vec<Product>>),
     LoadoutsOnline(LoadoutsOnline),
-    StatEvent(bool, u32),
+    StatEvent(StatEvent),
     Rotation(Rotation),
     RepStatTitle(RepStatTitle),
 }
@@ -183,6 +183,12 @@ pub struct Loadout {
 pub struct TeamLoadout {
     pub blue: Loadout,
     pub orange: Loadout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct StatEvent {
+    pub unknown1: bool,
+    pub object_id: i32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -629,10 +635,13 @@ impl AttributeDecoder {
 
     pub fn decode_stat_event(&self, bits: &mut BitGet<'_>) -> Result<Attribute, AttributeError> {
         if_chain! {
-            if let Some(u1) = bits.read_bit();
-            if let Some(id) = bits.read_u32();
+            if let Some(unknown1) = bits.read_bit();
+            if let Some(object_id) = bits.read_i32();
             then {
-                Ok(Attribute::StatEvent(u1, id))
+                Ok(Attribute::StatEvent(StatEvent {
+                    unknown1,
+                    object_id,
+                }))
             } else {
                 Err(AttributeError::NotEnoughDataFor("Stat Event"))
             }

--- a/tests/samples.rs
+++ b/tests/samples.rs
@@ -1,4 +1,4 @@
-use boxcars::attributes::{ActiveActor, Demolish, Pickup, RigidBody, Welded};
+use boxcars::attributes::{ActiveActor, Demolish, Pickup, RigidBody, StatEvent, Welded};
 use boxcars::{
     self, ActorId, NetworkError, ParseError, ParserBuilder, Quaternion, Trajectory, Vector3f, Vector3i,
 };
@@ -331,6 +331,20 @@ fn test_quaternions() {
             z: 17,
         }
     );
+
+    let events: Vec<StatEvent> = frames
+        .iter()
+        .flat_map(|x| {
+            x.updated_actors.iter().filter_map(|x| {
+                if let boxcars::Attribute::StatEvent(x) = x.attribute {
+                    Some(x)
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+    assert_eq!(events[1].object_id, -1);
 }
 
 #[test]


### PR DESCRIPTION
The stat event attribute used to be a tuple with an unsigned field. The
tuple isn't descriptive of the available fields and the unsigned field
would display (2^32 - 1), which is incorrect. Therefore this commit
migrates to a struct with named fields with the object id as a signed
integer. I would have liked to have used `ObjectId`, but that is an
unsigned value so it is not as easy to slot in.