### PR TITLE
Remove if_chain dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ encoding_rs = "0.8"
 byteorder = "1"
 phf = { version = "0.8", features = ["macros"] }
 fnv = "1.0"
-if_chain = "1.0"
 bitter = "0.4.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,11 @@
 //! # run(filename).unwrap();
 //! ```
 
-#![recursion_limit = "1000"]
-
-#[macro_use]
-extern crate if_chain;
-
 #[macro_use]
 extern crate serde;
 
+#[macro_use]
+mod macros;
 pub use self::errors::{AttributeError, FrameContext, FrameError, NetworkError, ParseError};
 pub use self::models::*;
 pub use self::network::attributes::Attribute;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,7 @@
+macro_rules! get(
+    ($e:expr) => (match $e { Some(e) => e, None => return None })
+);
+
+macro_rules! get_or(
+    ($e:expr, $s:expr) => (match $e { Some(e) => Ok(e), None => return Err(AttributeError::NotEnoughDataFor($s)) })
+);


### PR DESCRIPTION
By removing `if_chain!`

- We have one less dependency
- There are less lines than before
- The lines that are left should be more understandable and more
  friendly to rust tools
- Remove the need to set recursion limits