### PR TITLE
Fix clippy matches expression

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -208,11 +208,7 @@ impl HeaderProp {
     /// assert_eq!(b.is_byte(), true);
     /// ```
     pub fn is_byte(&self) -> bool {
-        if let HeaderProp::Byte { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, HeaderProp::Byte { .. })
     }
 }
 


### PR DESCRIPTION
Hmm looks like this requires a bump to Rust 1.42.0 (released march of 2020). Maybe wait just a tad bit longer before bumping the minimum rust version