### PR TITLE
Expose the byte header fields

### DIFF
--- a/examples/property_counter.rs
+++ b/examples/property_counter.rs
@@ -27,7 +27,7 @@ fn count_properties(
                 format!("{}:array", new_prefix)
             }
             HeaderProp::Bool(_) => format!("{}:bool", new_prefix),
-            HeaderProp::Byte => format!("{}:byte", new_prefix),
+            HeaderProp::Byte { .. } => format!("{}:byte", new_prefix),
             HeaderProp::Float(_) => format!("{}:float", new_prefix),
             HeaderProp::Int(_) => format!("{}:int", new_prefix),
             HeaderProp::Name(_) => format!("{}:name", new_prefix),


### PR DESCRIPTION
Previously they were parsed but discarded.

Closes #126