### PR TITLE
Bump MSRV to 1.61 from 1.60

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.60.0
+          rust: 1.61.0
         - build: stable
           os: ubuntu-latest
           rust: stable


### PR DESCRIPTION
Due to a `syn` requirement. Seems minor enough.