### PR TITLE
Stable and efficient header prop serialization

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -289,14 +289,12 @@ impl Serialize for HeaderProp {
     {
         match *self {
             HeaderProp::Array(ref x) => {
+                #[derive(Serialize)]
+                struct Elem<'a>(#[serde(serialize_with = "pair_vec")] &'a [(String, HeaderProp)]);
+
                 let mut state = serializer.serialize_seq(Some(x.len()))?;
                 for inner in x {
-                    // Look for a better way to do this instead of allocating the intermediate map
-                    let mut els = HashMap::new();
-                    for (key, val) in inner.iter() {
-                        els.insert(key, val);
-                    }
-                    state.serialize_element(&els)?;
+                    state.serialize_element(&Elem(inner.as_slice()))?;
                 }
                 state.end()
             }


### PR DESCRIPTION
I was looking to do snapshot testing of replay JSON output to ensure stability for any future changes, but I realized that the output slightly changed from run to run.

The reason why is due to the serialization of header properties that used an intermediate hashmap, which doesn't guarantee iteration order from one run to the next.

By getting rid of the hashmap we improve efficiency (no wasteful allocations) and guarantee stable output.