### PR TITLE
Increase quaternion accuracy with fused multiply add

### DIFF
--- a/src/network/models.rs
+++ b/src/network/models.rs
@@ -115,7 +115,7 @@ impl Quaternion {
         let a = Quaternion::unpack(bits.peek_and_consume(18) as u32);
         let b = Quaternion::unpack(bits.peek_and_consume(18) as u32);
         let c = Quaternion::unpack(bits.peek_and_consume(18) as u32);
-        let extra = (1.0 - (a * a) - (b * b) - (c * c)).sqrt();
+        let extra = (c.mul_add(-c, b.mul_add(-b, a.mul_add(-a, 1.0)))).sqrt();
         match largest {
             0 => Some(Quaternion {
                 x: extra,

--- a/tests/snapshots/integration_tests__replay_snapshots@00bb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@00bb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/00bb.replay
 ---
 {
   "frames": 8175,
-  "hex": "0x0ed04e71df953561ccc02a0708d73db15af23dc1c3faff34b184e6da0df6ce9b"
+  "hex": "0xe3f20cdced90f7a72f45dd2b10914a4c0c9d48c95d580dc9dcde30457e579ca6"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@01d3e5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@01d3e5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/01d3e5.replay
 ---
 {
   "frames": 393,
-  "hex": "0xb19e81006218b16d38a75520fe9e46afc876e7d74a65b7131a29f6985ce06435"
+  "hex": "0x41b616b143ff8ca473eb4996ceb435b61eea500d8b0f90a6081378f8e1e59e6d"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@029d.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@029d.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/029d.replay
 ---
 {
   "frames": 13855,
-  "hex": "0x87a211239636de7f52f38814f9dba6f8f0e863fb0324483f2376893141e15176"
+  "hex": "0xeca0dfe4e7cd780eef263241b30adf759e930be42f50370c4fb630a7603c1551"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@0ca5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@0ca5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/0ca5.replay
 ---
 {
   "frames": 472,
-  "hex": "0xf936b1875746b1d3d11350dba4559d0701ffb43fbcd6357c84ee737eefde6f37"
+  "hex": "0xe00580deb925b39eb3e4787fbed187e0e6381ef534ea9d0f1fdb208fe0ac6f14"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@140a5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@140a5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/140a5.replay
 ---
 {
   "frames": 9082,
-  "hex": "0xfc36102f0eba693c3ccae6f0143f26e5fd9052fbd39f69a3727b615a3b10ae09"
+  "hex": "0x5ff27033d68fdad648c2b36edbc82d12185f2bcd9456cd4bec3805d3a8c384ce"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@181d6.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@181d6.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/181d6.replay
 ---
 {
   "frames": 11982,
-  "hex": "0xc4646c0e5ad30c3536e713755cc4a2860fecd8f0ccb2a7fb6b66c4c26bc68cd6"
+  "hex": "0xc513b06f4021fa879bc9ee4ce435e4fd55572c789c3efaf1a0f0c5d32a85b452"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@1ec9.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@1ec9.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/1ec9.replay
 ---
 {
   "frames": 332,
-  "hex": "0x16ed33e97a5f2662e6534719c609cd79c9a040fc8fbfe4a551be48b2d78a1e1d"
+  "hex": "0x3c1cfc2676127f0dacfb9547255f9b5e357939fea90ce54d3584f0e3289d7345"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@204c.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@204c.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/204c.replay
 ---
 {
   "frames": 9377,
-  "hex": "0x2cecef048ef65a8089b5acf5a5ba048876e99062598b6dd4c2a73d2c07ffca2c"
+  "hex": "0xae4af4c7153c047fbf681c282ceae699e77650fd8f51e5037c2376910a01ce7b"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@21a81.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@21a81.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/21a81.replay
 ---
 {
   "frames": 13539,
-  "hex": "0x9d09b6ee2b0dc2139342167da4f439da753cd073dd5ada05652275f9a4fa4ede"
+  "hex": "0xa3bd0418897d4460d202067c5f3109517d2eb3f8fd1c31b024e860650f66c013"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@419a.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@419a.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/419a.replay
 ---
 {
   "frames": 10183,
-  "hex": "0x17159f927393cfcd072d3abaf740a9cf0dbcd73270869fcb2c28f9eb2457742f"
+  "hex": "0x02b43f48bb88c15a69b5f18c6a33591bb5722eaa28ff0a2885f0ed6b54bd8da8"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@42f2.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@42f2.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/42f2.replay
 ---
 {
   "frames": 11642,
-  "hex": "0xaaf9bc0eefab73764143b09cd02d7d75b56ab7fa1d45d992909a0ccc4001d513"
+  "hex": "0xb8f60bda8124fdb5f015ea7c8502f2f28317159d0234cb966d5a1dec61279bbb"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@436d.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@436d.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/436d.replay
 ---
 {
   "frames": 10006,
-  "hex": "0x24f88075115858854367dd9c4dccb922b4c3eabdf9492d9084e19f59fdc5987b"
+  "hex": "0x55265438db6e3dcd825195fe43b23c3bb4a6db60d6bda0b53fc3f66624da4570"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@43a9.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@43a9.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/43a9.replay
 ---
 {
   "frames": 9143,
-  "hex": "0xa540e87d2bcf635244dc0cb7759db893fbcb2b0055650d1a6f54dbbef629be5a"
+  "hex": "0x3f1de9c45a9940ace0da9e0fff217ddff77f3f5668de8656b71b95f919599bac"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@4742.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@4742.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/4742.replay
 ---
 {
   "frames": 9875,
-  "hex": "0x22a2a8c6fdf07d81b1266d0b86fe104b56de299f3cf0d80455248cd6640a83f9"
+  "hex": "0x68ad419ba0cf80fc1499ec6012f83923b661ab9a97f8920100a5c2c2ef832cf1"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@4bc3b.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@4bc3b.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/4bc3b.replay
 ---
 {
   "frames": 9536,
-  "hex": "0xf8ec3a7c7f66ea133ff3d198704b9ac08c1de8f7a8813d546bc9a224181e4548"
+  "hex": "0x9579eb8b10be01091385b01fe6c9e6926cb653e6747a8fd338b30344e11732a3"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@52b5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@52b5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/52b5.replay
 ---
 {
   "frames": 10049,
-  "hex": "0xc7a658cb0f62f7dcd2560454aa3337d937a945ba24275a2713603b41274767f3"
+  "hex": "0x189cd7e966206ea094622baf5c63f20704d2a6a55042de11d3993a6b6b655311"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@57a6c.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@57a6c.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/57a6c.replay
 ---
 {
   "frames": 378,
-  "hex": "0x2103efee63cb37f39fa9d4963b3fd13a81d9715a263375e7269b14de6f417d5a"
+  "hex": "0x92e74b3be10e153ec810c7f355289bea4de787a21167d900e8f483217b9f5089"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@58b2.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@58b2.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/58b2.replay
 ---
 {
   "frames": 13875,
-  "hex": "0xf65cecf6646b75c5dadffb1d4b6b8db95d427df979d59d43962ec71c9713f9b1"
+  "hex": "0xc03cdd78f95f074163179e1931a1764e15ed80e00165754d7b1e08a328d18004"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@59d3.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@59d3.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/59d3.replay
 ---
 {
   "frames": 10309,
-  "hex": "0xab7ab2bc2dceb5d98dcd7268c5aab3ee9ee67aea9dab58964a14b734a5e16fa9"
+  "hex": "0x52631bfda85f5d3a69ce75a12b52e5432d7c1581dc30c27fbcb545631d8217e1"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@5a06.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@5a06.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/5a06.replay
 ---
 {
   "frames": 515,
-  "hex": "0x7c32b54179093ac18daa2804a56583d38a3f9e17683579c26f59ebf43bb2b742"
+  "hex": "0xc69b827228c6cb5bab201add357f3cd039baedc19703c43eddecec7107f6d4bb"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@5f97d.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@5f97d.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/5f97d.replay
 ---
 {
   "frames": 10780,
-  "hex": "0x0ba0245f7aad3707186621e6a9006a2c8b7ac59211530986ea4d5aa7779e8f41"
+  "hex": "0x908f9380cd4273faf5c5c9cb2d4aa5250221c2e5f6ed9c36a164756d307772f5"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@60dfe.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@60dfe.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/60dfe.replay
 ---
 {
   "frames": 9737,
-  "hex": "0xf25d183706f162f042e9583a3befa7050c5ec74af6232a3eadab106ccaacbe54"
+  "hex": "0x35aaef8e9622f08711855d8c824d6d3f4ee91774841bfe97c74cd7faa6505d06"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@6cc24.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@6cc24.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/6cc24.replay
 ---
 {
   "frames": 7319,
-  "hex": "0x6680e834c824753996fbc2f2e41512352e07441674faca97247dcbaaff9843e5"
+  "hex": "0x40136fe78762dd2670d968874fc6e7b196918d1ea91f592f8873368233b7f263"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@70204.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@70204.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/70204.replay
 ---
 {
   "frames": 9574,
-  "hex": "0x10d946852bfe470d4b31fe4ebde8592ccee9ef88671b29c6fd3408940ed7c0ec"
+  "hex": "0xfea1b26af5ee3d2a768b45d8c7777c5a2e1db2037dd8e85b8f84a4d53b899e7a"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@70865.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@70865.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/70865.replay
 ---
 {
   "frames": 8912,
-  "hex": "0x7c81b2e516aa37e0318527a5b3112b17099017c2a96c611f99a17e5ccf3b30db"
+  "hex": "0x17299a6971fef7e66299d4c5fe4f76e02827eb1dee45f6cdcf428f0f52605bf1"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@7256.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@7256.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/7256.replay
 ---
 {
   "frames": 9634,
-  "hex": "0xc5ea328895e82296721d954c5d6ddd1e7d14a8a35d5c7bf8b46226611d735cbc"
+  "hex": "0x01cbb2f5e7c9d977081f388f80ad93f6e255b91b1f2e2d7c60c7b5d7b352f15e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@72ae1.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@72ae1.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/72ae1.replay
 ---
 {
   "frames": 8545,
-  "hex": "0x5e9054817e5e99ce12f238f2ac30e7aecaadc6769b480a27cdb2150cf47af5f9"
+  "hex": "0x1f7bda6d7bd89be485d7b582d2195e9f8563a7823c968930ba9aa54158828954"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@74936.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@74936.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/74936.replay
 ---
 {
   "frames": 10609,
-  "hex": "0xd22788c9bd17c9b3142b8114aff5d8e9156e86d9247517ce9a1b848b856f28b3"
+  "hex": "0x95d4f2e79156ee79e633a317d9a70302e6c20bb233bbf8653d9bd87e436227c6"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@79ea6.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@79ea6.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/79ea6.replay
 ---
 {
   "frames": 6147,
-  "hex": "0x80ebd61b91d140e2dbc8d34965e97859c29d5c985062645fdbb1fce89ec91f06"
+  "hex": "0x6af0a807e146c445a07144d2870328422d85e609939de16bdfd76f344f7fcef5"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@7f79f.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@7f79f.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/7f79f.replay
 ---
 {
   "frames": 12273,
-  "hex": "0xe841807a6cd84ffc9493cdcc5cb6ca4a4721662768eae5ead00f9a5c46f231ca"
+  "hex": "0xf67589c0965261f68cd5041a14713d8516a7cd38ef8b7a8b5080ebaf3bafca24"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@9a2cd.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@9a2cd.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/9a2cd.replay
 ---
 {
   "frames": 2616,
-  "hex": "0x8d4b87fdc6d5f74aaba5f2a8d2f96d7e58a192fe4e5c3f9aa399505fced8b8f0"
+  "hex": "0x54904be45adf07eab2d3107069624d07ddba586b28e03090008f6bef9157ff9f"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@9e35b.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@9e35b.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/9e35b.replay
 ---
 {
   "frames": 12859,
-  "hex": "0x199ec9793821985dbaf9e1e801c8feabf01a2e0a01a6d95624d159a009f3905b"
+  "hex": "0x0a0653918606e0501b5e14bf77d9bbe07814a583af613b1a1ceb1e13602e7f88"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@a184.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@a184.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/a184.replay
 ---
 {
   "frames": 604,
-  "hex": "0xc50fb45431d45ad9849eda1a18d7b1feb98972b5eddb821c2fd12f6f84c8d31a"
+  "hex": "0xc12007622e5083d839fa1c64c4767d60e9003c6d8ca093c832851a1b9a900e78"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@a9df3.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@a9df3.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/a9df3.replay
 ---
 {
   "frames": 330,
-  "hex": "0x98125ebd90cafc836ae1287876b956d64835e8166abd6bebe28ce1bb6cb0f023"
+  "hex": "0xae1dbbd2c502062fc1f739e4e11827deb61551610977d20d9891ffb8d17ae11d"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@c23b0.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@c23b0.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/c23b0.replay
 ---
 {
   "frames": 9811,
-  "hex": "0xc8459b04185c5227928a295e3e90f1509e1d6925793478201e537d804b845019"
+  "hex": "0x8d257039aa1a57e57412e3f56212a81747e7b07b8e86bcaf02d7ee587aeeccbe"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@c4abb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@c4abb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/c4abb.replay
 ---
 {
   "frames": 9093,
-  "hex": "0x9c1fc24b9b21ec4c81f5ffca721901de6ad6b33e58402b7fe2104429862757fe"
+  "hex": "0x96bed6ebd6b5de4df27c6d8fd28339ba552c6576951ed86831a8db86b748afe6"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d1d5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d1d5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d1d5.replay
 ---
 {
   "frames": 4454,
-  "hex": "0x0078560e4691cbce1ac2a2bbd98c8de2f8add81f44b91192ca901a712cc69550"
+  "hex": "0x6bf5983ddf3111419aa1ddcf3303dcd3a2fa9482ce0ba6394ee4ec624419d750"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d4f3b_heat.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d4f3b_heat.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d4f3b_heat.replay
 ---
 {
   "frames": 8920,
-  "hex": "0x964f8235c9b643096cadc68b0bc08d00d00699a9323f1ff97ec08e250b89ee7a"
+  "hex": "0x7f6c119bee0e47a779f7330c1fc769574c02bfd152865d617b5136bba2ab1a0e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d52eb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d52eb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d52eb.replay
 ---
 {
   "frames": 17815,
-  "hex": "0x8286102a058033f49cc10a54ac1a671cf7aaf634d08cebc759e9ca678eea0e2a"
+  "hex": "0xad196991d6aeb89c2501214d114145877ff628132cd3e315b99ffb7747fc9b9b"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@difficulty.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@difficulty.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/difficulty.replay
 ---
 {
   "frames": 3897,
-  "hex": "0x619e827d6456a3e9cbda142d626f927c615330e31c6a31dec4ee7e08d0b09156"
+  "hex": "0x3e04e16f51f7fed1ebf192e0a947385c888f0d04770287b2ae82d7ca88f8eecd"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@e978.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@e978.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/e978.replay
 ---
 {
   "frames": 9501,
-  "hex": "0x8f13f1da7a0cf0ddc9ae3448f81e33dcc61183e463be3f732f52c0ff326e0278"
+  "hex": "0x4ae612fcf7203211c50c1b1b9fe2de2c20e2c7df862f0dc917dec43c04da38f9"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@ed6ce_heat.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@ed6ce_heat.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/ed6ce_heat.replay
 ---
 {
   "frames": 10920,
-  "hex": "0x31a28695f3c5cf9e461af5173aeca34a228701bad123f8f7d4f6a6eac72b5601"
+  "hex": "0x3e98977f010c4ad41134cd6a9b551209cbb5344e9c60d4eed6d112ff0f629081"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@edbb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@edbb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/edbb.replay
 ---
 {
   "frames": 356,
-  "hex": "0x4164395b699f4ea0fd308e5eb079c29e57cfc7bc375bf6b3d8a79156c193b972"
+  "hex": "0xa1c86ca8b3cec60ea8d2146f1a7a040913123bd9c27424cb00d16a873b9a1bf2"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@epic.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@epic.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/epic.replay
 ---
 {
   "frames": 7231,
-  "hex": "0xa16332824e08e2d4f3a9f26d286ab7ef8d2c750fe51cbb47ed3472f2b7868877"
+  "hex": "0x31d3748adfd5ac4550e40e772de696ad5cdb37c243538e5069fa73c7975d57d6"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@fc427.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@fc427.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/fc427.replay
 ---
 {
   "frames": 9343,
-  "hex": "0xb9e449baa16817edd6b7a7e58ab2f66bcc70d79dd965db2f31a77d35720ad997"
+  "hex": "0x6d9819844b602e86dcc8dcbbf0c68e0c834a059ef319c8255f1ff03f20650ec6"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@fecd.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@fecd.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/fecd.replay
 ---
 {
   "frames": 12180,
-  "hex": "0xc9ae542276c7c931ed4bbfa6d4bb5cd31671d5b31958b9a4827bf4d2c22797d7"
+  "hex": "0xe2c28d28ad6119559a04993ed70c2217791d94a6d0329aa08282df48e55c15ad"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@gridiron.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@gridiron.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/gridiron.replay
 ---
 {
   "frames": 11118,
-  "hex": "0x349fbb17ff5ec0b88713dcf19a2277790fa6cebdc94d36ca7ff177a4114cdfb0"
+  "hex": "0xb5c44d9ff3e3c802bfd8c378899a207d605a3493575ecdef006ab9912e366d94"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@rl-178.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@rl-178.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/rl-178.replay
 ---
 {
   "frames": 8901,
-  "hex": "0xa7e90e5aa7dc731ece7772bd7fcc1c19b1e3718a01756f5afec90869474f3d54"
+  "hex": "0xd13ecebc64643d770e6aaa089385f692bd59fa6b7042ea5d6f7c6b0234ff5607"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@rlcs2.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@rlcs2.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/rlcs2.replay
 ---
 {
   "frames": 10664,
-  "hex": "0x4c72b4bcfd2d334d6fe9c766dc66a0c6bc14da74c5cc22fc562f676471d568b5"
+  "hex": "0xaa14a1b26429514a70f4827b1017239ce7b8d2c5aaec25c983da93383775ea1b"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@tourny.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@tourny.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/tourny.replay
 ---
 {
   "frames": 10275,
-  "hex": "0xac34d48d4cb232414eba274102ac7a41def31bee09994ac487edcc27cf598d98"
+  "hex": "0x6800abcb341ac849f5ab3cc585bd6c264e39f7f597f49cd5e5b8f422149e6cd9"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@voice_update.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@voice_update.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/voice_update.replay
 ---
 {
   "frames": 786,
-  "hex": "0x030b694b7bef467bace84d8cb438a7f3450e6a3fdff48f719a5ad29931f15fa3"
+  "hex": "0xce6025185919a704c07d5f638387ac19b49774e2b828bdd0e69e065e9e5137e7"
 }


### PR DESCRIPTION
The diffs appear to be inconsequential, here is the diff of this change on one of the JSON outputs:

```plain
<                   "x": 0.8544647,
---
>                   "x": 0.85446465,
```

Still, better to be more accurate than not.