### PR TITLE
Add iterator for inheritance hierarchy object ids

### DIFF
--- a/src/network/models.rs
+++ b/src/network/models.rs
@@ -340,6 +340,12 @@ impl Trajectory {
 /// `TheWorld:PersistentLevel.VehiclePickup_Boost_TA` so that we don't have to work around each
 /// stadium and pickup that is released.
 pub(crate) fn normalize_object(name: &str) -> &str {
+    if name.len() <= "TheWorld:PersistentLevel.CrowdActor_TA".len()
+        || !name.contains("TheWorld:PersistentLevel.")
+    {
+        return name;
+    }
+
     if name.contains("TheWorld:PersistentLevel.CrowdActor_TA") {
         "TheWorld:PersistentLevel.CrowdActor_TA"
     } else if name.contains("TheWorld:PersistentLevel.CrowdManager_TA") {


### PR DESCRIPTION
- This formalizes walking up the inheritance chain into a rust iterator to make it easier to work with.
- This allowed some simplification in deriving spawn stats and network attributes.
- Normalize object is now called more frequently and needed a dash of optimizations to prevent performance regressions.