### PR TITLE
+25% throughput with segmented arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ with the following options and the estimated elapsed time.
 
 | Header | Corruption Check | Body | Output JSON | Elapsed | Throughput |
 | -      | -                | -    | -           | -       | -          |
-| ✔      |                  |      |             | 68.0 µs |            |
-| ✔      | ✔                | ✔    |             | 6.6 ms | 223 MiB/s  |
-| ✔      |                  | ✔    |             | 6.3 ms | 232 MiB/s  |
-| ✔      | ✔                | ✔    | ✔           | 35 ms |  531 MiB/s ^1  |
+| ✔      |                  |      |             | 32 µs |            |
+| ✔      | ✔                | ✔    |             | 5.1 ms | 290 MiB/s  |
+| ✔      |                  | ✔    |             | 4.8 ms | 315 MiB/s  |
+| ✔      | ✔                | ✔    | ✔           | 31 ms |  600 MiB/s ^1  |
 
 ^1: JSON serialization throughput includes the amount of JSON produced
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -21,7 +21,7 @@ use std::cmp;
 pub(crate) struct CacheInfo {
     max_prop_id: u32,
     prop_id_bits: u32,
-    attributes: SegmentedArray<ObjectAttribute>,
+    attributes: SegmentedArray<StreamId, ObjectAttribute>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -148,7 +148,7 @@ pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames,
             .saturating_add(1);
         let mut attributes = SegmentedArray::new(64);
         for (k, v) in attrs {
-            attributes.insert(k.0 as usize, v);
+            attributes.insert(k, v);
         }
 
         let max_bit_width = crate::bits::bit_width(max as u64);

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -17,17 +17,17 @@ use fnv::FnvHashMap;
 use frame_decoder::SegmentedArray;
 use std::cmp;
 
-#[derive(Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) struct CacheInfo {
-    max_prop_id: u32,
-    prop_id_bits: u32,
-    attributes: SegmentedArray<StreamId, ObjectAttribute>,
+    pub(crate) max_prop_id: u32,
+    pub(crate) prop_id_bits: u32,
+    pub(crate) attributes: SegmentedArray<StreamId, ObjectAttribute>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ObjectAttribute {
-    attribute: AttributeTag,
-    object_id: ObjectId,
+    pub(crate) attribute: AttributeTag,
+    pub(crate) object_id: ObjectId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,13 +14,14 @@ use crate::models::*;
 use crate::network::frame_decoder::FrameDecoder;
 use crate::parser::ReplayBody;
 use fnv::FnvHashMap;
+use frame_decoder::SegmentedArray;
 use std::cmp;
 
 #[derive(Debug)]
-pub(crate) struct CacheInfo<'a> {
+pub(crate) struct CacheInfo {
     max_prop_id: u32,
     prop_id_bits: u32,
-    attributes: &'a FnvHashMap<StreamId, ObjectAttribute>,
+    attributes: SegmentedArray<ObjectAttribute>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -134,28 +135,37 @@ pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames,
         );
     }
 
-    let object_ind_attributes: FnvHashMap<ObjectId, CacheInfo> = object_ind_attrs
-        .iter()
-        .map(|(obj_id, attrs)| {
-            let id = *obj_id;
-            let max = attrs
-                .keys()
-                .map(|&x| i32::from(x))
-                .max()
-                .unwrap_or(2)
-                .saturating_add(1);
+    let mut object_ind_attributes: Vec<Option<CacheInfo>> = Vec::with_capacity(body.objects.len());
+    object_ind_attributes.resize_with(body.objects.len(), || None);
 
-            let max_bit_width = crate::bits::bit_width(max as u64);
-            Ok((
-                id,
-                CacheInfo {
-                    max_prop_id: max as u32,
-                    prop_id_bits: cmp::max(max_bit_width, 1) - 1,
-                    attributes: attrs,
-                },
-            ))
-        })
-        .collect::<Result<FnvHashMap<_, _>, NetworkError>>()?;
+    let iter = object_ind_attrs.into_iter().map(|(obj_id, attrs)| {
+        let id = obj_id;
+        let max = attrs
+            .keys()
+            .map(|&x| i32::from(x))
+            .max()
+            .unwrap_or(2)
+            .saturating_add(1);
+        let mut attributes = SegmentedArray::new(64);
+        for (k, v) in attrs {
+            attributes.insert(k.0 as usize, v);
+        }
+
+        let max_bit_width = crate::bits::bit_width(max as u64);
+        Ok((
+            id,
+            CacheInfo {
+                max_prop_id: max as u32,
+                prop_id_bits: cmp::max(max_bit_width, 1) - 1,
+                attributes,
+            },
+        ))
+    });
+
+    for x in iter {
+        let (object, cache) = x?;
+        object_ind_attributes[object.0 as usize] = Some(cache);
+    }
 
     let product_decoder = ProductValueDecoder::create(version, &object_index);
 

--- a/src/network/models.rs
+++ b/src/network/models.rs
@@ -259,6 +259,12 @@ impl From<StreamId> for i32 {
     }
 }
 
+impl From<StreamId> for usize {
+    fn from(val: StreamId) -> Self {
+        val.0 as usize
+    }
+}
+
 impl fmt::Display for StreamId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -273,6 +279,12 @@ pub struct ActorId(pub i32);
 impl From<ActorId> for i32 {
     fn from(x: ActorId) -> i32 {
         x.0
+    }
+}
+
+impl From<ActorId> for usize {
+    fn from(val: ActorId) -> Self {
+        val.0 as usize
     }
 }
 


### PR DESCRIPTION
For every updated actor in the network body, there are two hash functions run. One to lookup the actor id to grab their object id, and another to look up that object id's attributes. Even with the fastest hash function (FNV), this is still slow when executed a 100k times in a replay.

The solution is to transition the hashmap to a segmented array where small indices (which are the vast majority of them) are looked up directly in a sparse array with a static size. Indices that fall outside the array are still stored in a hashmap.

Benchmarks showed a +25% throughput improvement, which imo is kinda incredible that such performance improvements are still on the table.

The error reporting has been updated for missing or unimplemented attributes to look like:

```
An error occurred: Error decoding frame: attribute unknown or not implemented:
----------
actor id: 48
actor object id: 299
attribute stream id: 64
attribute: TAGame.Car_TA:ReplicatedDemolishExtended

Current frame: 2067 (time: 103.317894 delta: 0.034910098)

Last actor update:
------------------
actor id: 48
object id: 299
object name: Archetypes.Car.Car_Default
attribute stream id: 42
attribute object id: 46
attribute object name: TAGame.RBActor_TA:ReplicatedRBState
attribute: RigidBody(RigidBody { sleeping: true, location: Vector3f { x: 3207.58, y: 1563.85, z: 18.79 }, rotation: Quaternion { x: 0.0021228525, y: -0.0011140255, z: 0.8811583, w: 0.47281522 }, linear_velocity: None, angular_velocity: None })
```

Which should be much easier to parse than putting everything on a single line.

I included the error change in this PR as I don't want to expose segmented arrays to the world, so I clamped down on what is exposed in the framecontext.