### PR TITLE
Branchless buffer refills for vector decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1", features = ["derive"] }
 encoding_rs = "0.8"
 phf = { version = "0.11", features = ["macros"] }
 fnv = "1.0"
-bitter = "0.7"
+bitter = "0.7.1"
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
This reduces the number instructions emitted by nearly half when we check if there is enough data to blindly refill the lookahead. The best part, we don't even need to use the unchecked API to blindly refill -- somehow the compiler can figured this out when we ensure there is at least 16 bytes left unbuffered. Crazy.

Will wait for #188 to be merged and the bitter release before taking profiling results, hopefully this moves the needle somewhat. In other profiling runs, vector decoding is around 20% of the total CPU time.