### PR TITLE
Execute regression tests 4x faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ harness = false
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
+ryu.opt-level = 3
+serde_json.opt-level = 3
+highway.opt-level = 3


### PR DESCRIPTION
- Stop computing CRC in tests. So slow in debug mode.
- Buffer writes to hasher
- Optimize hotspot dependencies: json formatting and hashing