### PR TITLE
Change NewColor product value from i32 to u32

### DIFF
--- a/src/network/attributes.rs
+++ b/src/network/attributes.rs
@@ -374,7 +374,7 @@ pub enum ProductValue {
     NoColor,
     Absent,
     OldColor(u32),
-    NewColor(i32),
+    NewColor(u32),
     OldPaint(u32),
     NewPaint(u32),
     Title(String),
@@ -461,7 +461,7 @@ impl ProductValueDecoder {
     ) -> Option<ProductValue> {
         if obj_ind == self.color_ind {
             if self.version >= VersionTriplet(868, 23, 8) {
-                bits.read_i32().map(ProductValue::NewColor)
+                bits.read_u32().map(ProductValue::NewColor)
             } else {
                 bits.if_get(|b| {
                     b.read_bits(31)

--- a/tests/snapshots/integration_tests__replay_snapshots@00bb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@00bb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/00bb.replay
 ---
 {
   "frames": 8175,
-  "hex": "0xe3f20cdced90f7a72f45dd2b10914a4c0c9d48c95d580dc9dcde30457e579ca6"
+  "hex": "0x9eaf91f07790b707635ad72577c1c3c22a033098feb903f283def803d43c38cc"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@029d.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@029d.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/029d.replay
 ---
 {
   "frames": 13855,
-  "hex": "0xe0f9d259de446687abbe0e5563eaee42328a3aa617b47e72bf4a0f9b5fe3c239"
+  "hex": "0x8b282a11fcc040fea04e50b6b20c1b8f770c2d173e02ed60f4892432786a4a67"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@0ca5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@0ca5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/0ca5.replay
 ---
 {
   "frames": 472,
-  "hex": "0xe00580deb925b39eb3e4787fbed187e0e6381ef534ea9d0f1fdb208fe0ac6f14"
+  "hex": "0x671a07408e9be4e9a4f93d0bf872e51080dff59a16db6701819e72346973eabd"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@140a5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@140a5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/140a5.replay
 ---
 {
   "frames": 9082,
-  "hex": "0x5ff27033d68fdad648c2b36edbc82d12185f2bcd9456cd4bec3805d3a8c384ce"
+  "hex": "0x8893eef8aba23bda46dc1b9e0908a1a6e0f2ec5437afd5265625c2981f7bdf03"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@181d6.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@181d6.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/181d6.replay
 ---
 {
   "frames": 11982,
-  "hex": "0x35a53c077470d3c9706bfa88b9682df5c2538b7102389c3a36d8e0706ca7223c"
+  "hex": "0xa117fbd977b2011f939e09877fd910c2d9f2e474b456b8a93e8ccf83283249cb"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@1ec9.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@1ec9.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/1ec9.replay
 ---
 {
   "frames": 332,
-  "hex": "0x3c1cfc2676127f0dacfb9547255f9b5e357939fea90ce54d3584f0e3289d7345"
+  "hex": "0xcec4004e5f7c25610504dfd8e63c46e188ca07fdb3e4a607a1bcc77d3663f3f5"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@204c.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@204c.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/204c.replay
 ---
 {
   "frames": 9377,
-  "hex": "0x40ffe97b52abf35b2772a104761466a57813549a0ac4b1f828fa2a5c6c01e79a"
+  "hex": "0x5e40c497d69ec5cb075da3c8b8c0c228b9f40c37017b7231df143d455dc41517"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@21a81.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@21a81.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/21a81.replay
 ---
 {
   "frames": 13539,
-  "hex": "0xa3bd0418897d4460d202067c5f3109517d2eb3f8fd1c31b024e860650f66c013"
+  "hex": "0x8efc97b8456b7ea06855b103ca08a24385bcd2f33d3f5929fc017b479f1fd363"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@3bd08.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@3bd08.replay.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/integration_tests.rs
-assertion_line: 38
 expression: snapshot
 input_file: assets/replays/good/3bd08.replay
 ---
 {
   "frames": 283,
-  "hex": "0x08b854df175145a7554677f3d5eb5b4466f74ab9a8fb3165d374135745d1f2be"
+  "hex": "0x1ea305e4635820301bcf4a6fd6cf4f97030f7859a7ed4bdeabb33612255f4fd9"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@419a.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@419a.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/419a.replay
 ---
 {
   "frames": 10183,
-  "hex": "0x02b43f48bb88c15a69b5f18c6a33591bb5722eaa28ff0a2885f0ed6b54bd8da8"
+  "hex": "0x47091005f172b44fd443e5f1c4fa60e3467e60f168401ec8244c882978b6855a"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@42f2.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@42f2.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/42f2.replay
 ---
 {
   "frames": 11642,
-  "hex": "0xb8f60bda8124fdb5f015ea7c8502f2f28317159d0234cb966d5a1dec61279bbb"
+  "hex": "0xb889a212af6daf82f392995724559c8629a11701f471aa05ef0586e2d671aac6"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@436d.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@436d.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/436d.replay
 ---
 {
   "frames": 10006,
-  "hex": "0xb19fef69ec18ac11555ad9b77b21e229daf2fdcd64165defea7b9e258b0063e6"
+  "hex": "0x19abc4ce25080f47e85d69b8a1afb157a15866f92715ee72fbafc67ef958b3dd"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@43a9.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@43a9.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/43a9.replay
 ---
 {
   "frames": 9143,
-  "hex": "0x3f1de9c45a9940ace0da9e0fff217ddff77f3f5668de8656b71b95f919599bac"
+  "hex": "0x502e5dc26fba1c2638a8288376fa64d8cb012f8776eb8e5dbafc4d1cd1b3353e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@4742.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@4742.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/4742.replay
 ---
 {
   "frames": 9875,
-  "hex": "0xc98adaf8058805bcd10a708ec37b242428bad21e582383a8a71016098c5e82e2"
+  "hex": "0x76016cfcbdc75ff2f90bd50151c927da9ae6dbe664ffd9fcd6fe536caccb75c9"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@47eb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@47eb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/47eb.replay
 ---
 {
   "frames": 64406,
-  "hex": "0xc7aa9f7b0df7702e744c7edcd3de58482c29f02ffb2c5e910e8b7f33fdbf0459"
+  "hex": "0xb3e67e747743e82c1d5e43b98c86658ad39e672e9365bfe74cdcc707d2cf258d"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@4bc3b.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@4bc3b.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/4bc3b.replay
 ---
 {
   "frames": 9536,
-  "hex": "0x9579eb8b10be01091385b01fe6c9e6926cb653e6747a8fd338b30344e11732a3"
+  "hex": "0xd969fe6cd41518250111d0a4602509abfd67b0baa26528afcd05a11481dbc2ee"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@52b5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@52b5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/52b5.replay
 ---
 {
   "frames": 10049,
-  "hex": "0x9efe0c57931e3248cb61dcfcefb55e38143200aa133951d086dcb89250b0ccfe"
+  "hex": "0x270592b150d5a19ce1975a2b08cb8cae399a31fc22f3abbf7d5a59523f163730"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@58b2.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@58b2.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/58b2.replay
 ---
 {
   "frames": 13875,
-  "hex": "0xf786dacea0c5fe08a9fdddf763bf88628530142df36bbf2738e4bbf25ab572f1"
+  "hex": "0x672d1d1d292258bdbe9f78a9b01d440bf7c8541712cc48d4d6e278bbcb79c97e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@59d3.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@59d3.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/59d3.replay
 ---
 {
   "frames": 10309,
-  "hex": "0xdbd2fae7a423ca58bf576f85a6885779bab0d16d4c10a1d61e60bd9e555167c2"
+  "hex": "0x9fd4a0f007c26a5c8e6498207a91fe50683fe2c234a8539f554f6fe18ac1bdff"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@5a06.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@5a06.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/5a06.replay
 ---
 {
   "frames": 515,
-  "hex": "0xc69b827228c6cb5bab201add357f3cd039baedc19703c43eddecec7107f6d4bb"
+  "hex": "0x8e28bbca98da50ec9dcd012e0fe7687d1e697ca432fa99dc532bf1494db4af70"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@5f97d.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@5f97d.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/5f97d.replay
 ---
 {
   "frames": 10780,
-  "hex": "0x908f9380cd4273faf5c5c9cb2d4aa5250221c2e5f6ed9c36a164756d307772f5"
+  "hex": "0xfe22fc866401f0e36aa4fb8ef1dd46aabc7c7c2a0fe8c42b0abab7ffe9b01fb9"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@60dfe.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@60dfe.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/60dfe.replay
 ---
 {
   "frames": 9737,
-  "hex": "0x35aaef8e9622f08711855d8c824d6d3f4ee91774841bfe97c74cd7faa6505d06"
+  "hex": "0x4f948e34c8220014142b46e87401de3f623453a2bbdc7a34da98a39849a92401"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@70204.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@70204.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/70204.replay
 ---
 {
   "frames": 9574,
-  "hex": "0xfea1b26af5ee3d2a768b45d8c7777c5a2e1db2037dd8e85b8f84a4d53b899e7a"
+  "hex": "0xdf4c80c1d45da1dc31828a222b331ce14dac473863e642e470dd9033e58be838"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@70865.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@70865.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/70865.replay
 ---
 {
   "frames": 8912,
-  "hex": "0x17299a6971fef7e66299d4c5fe4f76e02827eb1dee45f6cdcf428f0f52605bf1"
+  "hex": "0x2ffa412e7715f07d48a462b755832a5f19ba08d2d9fbdc5b3142d94e458dbdac"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@7256.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@7256.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/7256.replay
 ---
 {
   "frames": 9634,
-  "hex": "0x01cbb2f5e7c9d977081f388f80ad93f6e255b91b1f2e2d7c60c7b5d7b352f15e"
+  "hex": "0xa82b103e7d8fedf4ad90028ee260e67dbabdf89ca30d5bc9ad3721648e0c83ba"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@72ae1.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@72ae1.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/72ae1.replay
 ---
 {
   "frames": 8545,
-  "hex": "0x1f7bda6d7bd89be485d7b582d2195e9f8563a7823c968930ba9aa54158828954"
+  "hex": "0xd8a7064849ad6ce231e1936fad83ef35fe85c499947a9cf31f1225808d0e5f20"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@74936.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@74936.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/74936.replay
 ---
 {
   "frames": 10609,
-  "hex": "0x95d4f2e79156ee79e633a317d9a70302e6c20bb233bbf8653d9bd87e436227c6"
+  "hex": "0xaf31de919e74ebb8a9e926135c838c32f374cef802a9b390ff9a1913454797d8"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@79ea6.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@79ea6.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/79ea6.replay
 ---
 {
   "frames": 6147,
-  "hex": "0x549b3c4b1cc2969d69511ca244f81a2df309319c5eea77b285451ab0e665312c"
+  "hex": "0x083e08f36a100f9f4ef1af943fe870adddc92d7a58a1ac9b24b1f9d3095306e9"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@7f79f.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@7f79f.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/7f79f.replay
 ---
 {
   "frames": 12273,
-  "hex": "0xf67589c0965261f68cd5041a14713d8516a7cd38ef8b7a8b5080ebaf3bafca24"
+  "hex": "0x49ccb379476f7e8663f2903c19875320758facbdc9aba3479ddd0eb6f5781380"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@8a26.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@8a26.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/8a26.replay
 ---
 {
   "frames": 10549,
-  "hex": "0xd2e0201e021605a64a74356ae231f6d69c66f08784ca8264f7427ab1edc6c64d"
+  "hex": "0xd074647f061b391bcd236d7cb8bb73c2c41d5a5350b7b4f90e3006c68763f44c"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@9a2cd.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@9a2cd.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/9a2cd.replay
 ---
 {
   "frames": 2616,
-  "hex": "0x54904be45adf07eab2d3107069624d07ddba586b28e03090008f6bef9157ff9f"
+  "hex": "0xfc8d48de75c3103c9edbc06af3cb821e3a0c26318f66515090bf06ea94dbd766"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@9e35b.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@9e35b.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/9e35b.replay
 ---
 {
   "frames": 12859,
-  "hex": "0x0a0653918606e0501b5e14bf77d9bbe07814a583af613b1a1ceb1e13602e7f88"
+  "hex": "0xeeaa524befefd0530a55da1dca37fafe85406ec7fb6ccb90770740e988abe6ae"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@9eee.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@9eee.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/9eee.replay
 ---
 {
   "frames": 10333,
-  "hex": "0xf574dbe7258e4416c3f872fda87e28c67fe0d5115ba6e9636451d9698d5a6a40"
+  "hex": "0x082bba124a08f8a5f5539c9bf26a46fa9ad9c891ebf5a4220d2c06ad5e695a27"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@a184.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@a184.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/a184.replay
 ---
 {
   "frames": 604,
-  "hex": "0xc12007622e5083d839fa1c64c4767d60e9003c6d8ca093c832851a1b9a900e78"
+  "hex": "0x05e9c756ae345bd7db2d77f409d216b09c7047e17d08a40dd3d60043e009942d"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@c23b0.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@c23b0.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/c23b0.replay
 ---
 {
   "frames": 9811,
-  "hex": "0x8d257039aa1a57e57412e3f56212a81747e7b07b8e86bcaf02d7ee587aeeccbe"
+  "hex": "0x4958c4b2aabf07ebc0dd9675cabfbbef775199345d3f1a754a5e3645570dff6e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@c4abb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@c4abb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/c4abb.replay
 ---
 {
   "frames": 9093,
-  "hex": "0x96bed6ebd6b5de4df27c6d8fd28339ba552c6576951ed86831a8db86b748afe6"
+  "hex": "0x4bbb5bb61857de8309652c81aa826367e3b99fd3fff1e7680f16273272f7d50e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@c8cf.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@c8cf.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/c8cf.replay
 ---
 {
   "frames": 13382,
-  "hex": "0xd0ff2982b1b0c6263a5c9ce67d114a813e59c9e85b46e44b7c7522285fe187df"
+  "hex": "0x27dc51d5bb575acde19d933bce8b880d32808085cb6ddbad1a896333c7eaa04c"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d1d5.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d1d5.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d1d5.replay
 ---
 {
   "frames": 4454,
-  "hex": "0x6bf5983ddf3111419aa1ddcf3303dcd3a2fa9482ce0ba6394ee4ec624419d750"
+  "hex": "0xce34e9406f45d9a486a271216738898d403dc6b6393076fea5bdff084d4c0528"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d4f3b_heat.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d4f3b_heat.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d4f3b_heat.replay
 ---
 {
   "frames": 8920,
-  "hex": "0x7f6c119bee0e47a779f7330c1fc769574c02bfd152865d617b5136bba2ab1a0e"
+  "hex": "0x60c93c06d98a5da30622184f38ae208b043c3a477cc22e7e40aadbb769829b56"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d52eb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d52eb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d52eb.replay
 ---
 {
   "frames": 17815,
-  "hex": "0xad196991d6aeb89c2501214d114145877ff628132cd3e315b99ffb7747fc9b9b"
+  "hex": "0xcce08c6a9911df3e184464f46c1c44bd500cd07001ddf758b8226518a23455b2"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@d9d9.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@d9d9.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/d9d9.replay
 ---
 {
   "frames": 11693,
-  "hex": "0xf45b703d14a65b622686cd7b97eea685c3ee4ddc926531610fa3f0be3481ad6f"
+  "hex": "0xe4ed0ce26ee690d19dc19b8149b4f9171f8193294f4884126b83417719b5d008"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@difficulty.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@difficulty.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/difficulty.replay
 ---
 {
   "frames": 3897,
-  "hex": "0x3e04e16f51f7fed1ebf192e0a947385c888f0d04770287b2ae82d7ca88f8eecd"
+  "hex": "0xe65d9638950c87eef969b7c204281518b4680d234e398ddb81a03d517b0eb788"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@e978.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@e978.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/e978.replay
 ---
 {
   "frames": 9501,
-  "hex": "0x4ae612fcf7203211c50c1b1b9fe2de2c20e2c7df862f0dc917dec43c04da38f9"
+  "hex": "0xaee83486bc807d676282994b7436d4b24241942aee0085526a6315ace34b4e38"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@ed6ce_heat.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@ed6ce_heat.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/ed6ce_heat.replay
 ---
 {
   "frames": 10920,
-  "hex": "0x3e98977f010c4ad41134cd6a9b551209cbb5344e9c60d4eed6d112ff0f629081"
+  "hex": "0xc76ece767a4ae238fc560524342a81207bd26f9046b7c92cf830d096add30d1a"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@edbb.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@edbb.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/edbb.replay
 ---
 {
   "frames": 356,
-  "hex": "0xa1c86ca8b3cec60ea8d2146f1a7a040913123bd9c27424cb00d16a873b9a1bf2"
+  "hex": "0xb3585b73c1e66706efc172d7ecde74b128fb414929c1840cb71f24ef9de4354c"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@epic.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@epic.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/epic.replay
 ---
 {
   "frames": 7231,
-  "hex": "0x31d3748adfd5ac4550e40e772de696ad5cdb37c243538e5069fa73c7975d57d6"
+  "hex": "0xf7b4e19d56363d072658947a7c0d22baad91eeae33e345835d1e72bf08524541"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@f770.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@f770.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/f770.replay
 ---
 {
   "frames": 18324,
-  "hex": "0x96ee045b4edc9ee5b98082f621191adb677bf2326bd50f59233de6b9ff85f910"
+  "hex": "0x47bb9ab5c9246b228a677f112ac503270f0874ae6133d7f2623fc0e67f8ab0a8"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@fc427.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@fc427.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/fc427.replay
 ---
 {
   "frames": 9343,
-  "hex": "0x6d9819844b602e86dcc8dcbbf0c68e0c834a059ef319c8255f1ff03f20650ec6"
+  "hex": "0x69387daae306dcc8892aa4a3f28b982edf110f71817ff9813887dd97f1a1e82e"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@fecd.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@fecd.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/fecd.replay
 ---
 {
   "frames": 12180,
-  "hex": "0xe2c28d28ad6119559a04993ed70c2217791d94a6d0329aa08282df48e55c15ad"
+  "hex": "0xaf1e87ee50d70561ce0c73353ec688649e1ecd84f63daff31d10155f0549134b"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@gridiron.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@gridiron.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/gridiron.replay
 ---
 {
   "frames": 11118,
-  "hex": "0xb5c44d9ff3e3c802bfd8c378899a207d605a3493575ecdef006ab9912e366d94"
+  "hex": "0xd87cb0b7907532f62f23c246169079627d69f1eeed57839ec4b3c4a3988ef1c1"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@rl-178.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@rl-178.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/rl-178.replay
 ---
 {
   "frames": 8901,
-  "hex": "0xd13ecebc64643d770e6aaa089385f692bd59fa6b7042ea5d6f7c6b0234ff5607"
+  "hex": "0x8f706da482b754d6c13742c7986e7b55bcff1e6930723298f356d42d86d74d7f"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@rlcs2.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@rlcs2.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/rlcs2.replay
 ---
 {
   "frames": 10664,
-  "hex": "0xaa14a1b26429514a70f4827b1017239ce7b8d2c5aaec25c983da93383775ea1b"
+  "hex": "0xdce125fd7e3ed680b02b495e1528f37c3eaf09054c1b3f76533ca382a807e6f8"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@tourny.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@tourny.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/tourny.replay
 ---
 {
   "frames": 10275,
-  "hex": "0x6800abcb341ac849f5ab3cc585bd6c264e39f7f597f49cd5e5b8f422149e6cd9"
+  "hex": "0x0fff89ca3430dbd139313f2dd2eb2b33354e2ba9570b3a088b848491b9e4b9fb"
 }

--- a/tests/snapshots/integration_tests__replay_snapshots@voice_update.replay.snap
+++ b/tests/snapshots/integration_tests__replay_snapshots@voice_update.replay.snap
@@ -5,5 +5,5 @@ input_file: assets/replays/good/voice_update.replay
 ---
 {
   "frames": 786,
-  "hex": "0xce6025185919a704c07d5f638387ac19b49774e2b828bdd0e69e065e9e5137e7"
+  "hex": "0x0be1a67882a4bde7737ab71ef1ec41e666332051a2dcd160174361fc8e268435"
 }


### PR DESCRIPTION
Ref #152 and https://github.com/nickbabcock/boxcars/issues/195#issuecomment-2582709439

This is a breaking change (as evident by all the test cases that needed to be updated).

I'm assuming, ideally, these should be serialized as hex, but doesn't look like any of the other parsers do so.