### PR TITLE
Re-enable CRC for regression tests

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -32,7 +32,9 @@ const fn gen_crc_table<const N: usize>(poly: u32) -> [[u32; 256]; N] {
     table
 }
 
-const CRC_TABLE: [[u32; 256]; 16] = gen_crc_table(0x04c1_1db7);
+// Prefer static over const to cut test times in half
+// ref: https://github.com/srijs/rust-crc32fast/commit/e61ce6a39bbe9da495198a4037292ec299e8970f
+static CRC_TABLE: [[u32; 256]; 16] = gen_crc_table(0x04c1_1db7);
 
 /// Calculates the crc-32 for rocket league replays. Not all CRC algorithms are the same. The crc
 /// algorithm can be generated with the following parameters (pycrc):

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,7 +8,7 @@ fn test_replay_snapshots() {
     glob!("../assets/replays/good", "*.replay", |path| {
         let data = fs::read(path).unwrap();
         let parsed = ParserBuilder::new(&data[..])
-            .on_error_check_crc() // CRC checking in debug mode makes tests 2x slower
+            .always_check_crc()
             .must_parse_network_data()
             .parse();
 


### PR DESCRIPTION
Turns out the compiler is horrible about const arrays in debug mode :)

I tested that this had no impact for production performance.