### PR TITLE
Remove ryu.opt-level from dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,5 @@ harness = false
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
-ryu.opt-level = 3
 serde_json.opt-level = 3
 highway.opt-level = 3


### PR DESCRIPTION
This fixes a build warning as I guess ryu is no longer part of the dependency tree