### PR TITLE
Bump insta to latest for snapshot filter fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["derive"] }
 criterion = "0.8"
 gungraun = "0.17.2"
 highway = "1.3.0"
-insta = { version = "1.39.0", features = ["glob", "serde", "json"] }
+insta = { version = "1.47.0", features = ["glob", "serde", "json"] }
 serde_json = "1"
 
 [profile.bench]


### PR DESCRIPTION
By updating insta to 1.43.2 we get the following fix "Preserve snapshot names with INSTA_GLOB_FILTER".

Makes it a bit easier to run just a subset of the snapshot tests:

```
INSTA_GLOB_FILTER="00bb.replay" cargo test
```