### PR TITLE
Remove secondary object index handling

### DIFF
--- a/src/network/attributes.rs
+++ b/src/network/attributes.rs
@@ -433,19 +433,19 @@ pub(crate) struct ProductValueDecoder {
 impl ProductValueDecoder {
     pub fn create(version: VersionTriplet, object_index: &ObjectIndex) -> Self {
         let color_ind = object_index
-            .primary_by_name("TAGame.ProductAttribute_UserColor_TA")
+            .by_name("TAGame.ProductAttribute_UserColor_TA")
             .unwrap_or_default();
         let painted_ind = object_index
-            .primary_by_name("TAGame.ProductAttribute_Painted_TA")
+            .by_name("TAGame.ProductAttribute_Painted_TA")
             .unwrap_or_default();
         let title_ind = object_index
-            .primary_by_name("TAGame.ProductAttribute_TitleID_TA")
+            .by_name("TAGame.ProductAttribute_TitleID_TA")
             .unwrap_or_default();
         let special_edition_ind = object_index
-            .primary_by_name("TAGame.ProductAttribute_SpecialEdition_TA")
+            .by_name("TAGame.ProductAttribute_SpecialEdition_TA")
             .unwrap_or_default();
         let team_edition_ind = object_index
-            .primary_by_name("TAGame.ProductAttribute_TeamEdition_TA")
+            .by_name("TAGame.ProductAttribute_TeamEdition_TA")
             .unwrap_or_default();
 
         ProductValueDecoder {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -52,13 +52,11 @@ pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames,
     // when they spawn as a new actor
     let mut spawns: Vec<Option<SpawnTrajectory>> = vec![None; body.objects.len()];
     for (object_name, spawn) in SPAWN_STATS.iter() {
-        let Some(id) = object_index.primary_by_name(object_name) else {
+        let Some(id) = object_index.by_name(object_name) else {
             continue;
         };
 
-        for i in object_index.all_indices(id) {
-            spawns[i.0 as usize] = Some(*spawn);
-        }
+        spawns[id.0 as usize] = Some(*spawn);
     }
 
     let mut parent_stack = Vec::with_capacity(body.objects.len());
@@ -74,10 +72,7 @@ pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames,
             }
         }
 
-        let inds = parent_stack
-            .drain(..)
-            .flat_map(|ind| object_index.all_indices(ind));
-        for ind in inds {
+        for ind in parent_stack.drain(..) {
             spawns[ind.0 as usize] = Some(result)
         }
     }
@@ -86,8 +81,7 @@ pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames,
         FnvHashMap::with_capacity_and_hasher(body.net_cache.len(), Default::default());
     for cache in &body.net_cache {
         let key = ObjectId(cache.object_ind);
-        let primary_object = object_index.primary_by_index(key);
-        let properties = net_properties.entry(primary_object).or_default();
+        let properties = net_properties.entry(key).or_default();
         properties.reserve(cache.properties.len());
 
         for x in &cache.properties {
@@ -224,9 +218,7 @@ fn net_traversal(
         acc_attrs.extend(attrs);
         cache_attrs.clear();
         cache_attrs.extend(acc_attrs.iter().cloned());
-        for parent in object_index.all_indices(ind) {
-            object_ind_attrs.insert(parent, cache_attrs.clone());
-        }
+        object_ind_attrs.insert(ind, cache_attrs.clone());
     }
 }
 

--- a/src/network/object_index.rs
+++ b/src/network/object_index.rs
@@ -1,69 +1,31 @@
 use crate::{data::PARENT_CLASSES, ObjectId};
 use fnv::FnvHashMap;
-use std::collections::hash_map::Entry;
 
 use super::normalize_object;
 
 /// A lookup of an object's ID (its index in body.objects) from its name.
 ///
-/// The exact same name can appear multiple times in body.objects, so we
-/// designate these additional occurrences as "secondary IDs", and an
-/// `ObjectIndex` is a bidirectional map of primary to secondary IDs.
+/// The exact same name can appear multiple times in body.objects. In that
+/// case, the first occurrence is used for hierarchy lookups.
 pub(crate) struct ObjectIndex<'a> {
     name_index: FnvHashMap<&'a str, ObjectId>,
-    secondary_indices: FnvHashMap<ObjectId, Vec<ObjectId>>,
-    primary_ind: FnvHashMap<ObjectId, ObjectId>,
 }
 
 impl<'a> ObjectIndex<'a> {
     pub(crate) fn new(objects: &'a [String]) -> Self {
         let mut name_index: FnvHashMap<&str, ObjectId> = FnvHashMap::default();
-        let mut secondary_indices: FnvHashMap<ObjectId, Vec<ObjectId>> = FnvHashMap::default();
-        let mut primary_ind: FnvHashMap<ObjectId, ObjectId> = FnvHashMap::default();
 
         for (i, name) in objects.iter().enumerate() {
             let val = ObjectId(i as i32);
-            match name_index.entry(name) {
-                Entry::Occupied(occupied_entry) => {
-                    primary_ind.insert(val, *occupied_entry.get());
-                    secondary_indices
-                        .entry(*occupied_entry.get())
-                        .or_default()
-                        .push(val);
-                }
-                Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(val);
-                }
-            };
+            name_index.entry(name.as_str()).or_insert(val);
         }
 
-        Self {
-            name_index,
-            secondary_indices,
-            primary_ind,
-        }
+        Self { name_index }
     }
 
     /// Return primary `ObjectId` given the object name
-    pub(crate) fn primary_by_name(&self, name: &str) -> Option<ObjectId> {
+    pub(crate) fn by_name(&self, name: &str) -> Option<ObjectId> {
         self.name_index.get(name).copied()
-    }
-
-    /// Return the primary `ObjectId` given either a primary or secondary `ObjectId`
-    pub(crate) fn primary_by_index(&self, id: ObjectId) -> ObjectId {
-        self.primary_ind.get(&id).copied().unwrap_or(id)
-    }
-
-    /// Returns a list of equivalent `ObjectId` as the primary id passed in.
-    /// Includes self.
-    pub(crate) fn all_indices(&self, id: ObjectId) -> impl Iterator<Item = ObjectId> + '_ {
-        std::iter::once(id).chain(
-            self.secondary_indices
-                .get(&id)
-                .into_iter()
-                .flatten()
-                .copied(),
-        )
     }
 
     /// Returns the inheritance hierarchy `ObjectId` starting with self
@@ -84,7 +46,7 @@ impl Iterator for AncestorIterator<'_, '_> {
         loop {
             let current = self.name;
             self.name = PARENT_CLASSES.get(normalize_object(self.name))?;
-            if let sme @ Some(_) = self.index.primary_by_name(current) {
+            if let sme @ Some(_) = self.index.by_name(current) {
                 return sme;
             }
         }


### PR DESCRIPTION
Duplicate object names repeat inherited properties, so it is unnecessary to track them

128ed.replay contains the same object name more than once: `TAGame.GameEvent_Soccar_TA` exists at indices [162, 165].

Benchmarks showed a tenth of a percentage improvement in instruction count reduction.

Closes #274
