### PR TITLE
[codex] Add best-effort network recovery

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,7 @@
 /// numeric/string types). Asking "why JSON" would be next logical step, and that's due to other
 /// rocket league replay parsers (like Octane) using JSON; however, the output of this library is
 /// not compatible with that of other rocket league replay parsers.
-use crate::network::Frame;
+use crate::network::{Frame, NetworkWarning};
 use serde::ser::{SerializeMap, SerializeSeq, SerializeStruct};
 use serde::{Serialize, Serializer};
 
@@ -44,6 +44,10 @@ pub struct Replay {
 #[derive(Serialize, PartialEq, Debug, Clone)]
 pub struct NetworkFrames {
     pub frames: Vec<Frame>,
+
+    /// Warnings emitted by lossy network recovery modes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub network_warnings: Vec<NetworkWarning>,
 }
 
 /// In Rocket league replays, there are tickmarks that typically represent a significant event in

--- a/src/network/frame_decoder.rs
+++ b/src/network/frame_decoder.rs
@@ -2,11 +2,13 @@ use bitter::{BitReader, LittleEndianReader};
 use fnv::FnvHashMap;
 
 use crate::bits::RlBits;
-use crate::errors::{AttributeError, FrameContext, FrameError, NetworkError};
+use crate::errors::{FrameContext, FrameError, NetworkError};
 use crate::network::attributes::{AttributeDecoder, ProductValueDecoder};
 use crate::network::models::{
-    ActorId, Frame, NewActor, ObjectId, SpawnTrajectory, StreamId, Trajectory, UpdatedAttribute,
+    ActorId, Frame, NetworkWarning, NewActor, ObjectId, SpawnTrajectory, StreamId, Trajectory,
+    UpdatedAttribute,
 };
+use crate::network::recovery::{self, AttributeDecodeResult};
 use crate::network::{CacheInfo, VersionTriplet};
 use crate::parser::ReplayBody;
 
@@ -125,6 +127,7 @@ pub(crate) struct FrameDecoder<'a, 'b: 'a> {
     pub version: VersionTriplet,
     pub is_lan: bool,
     pub is_rl_223: bool,
+    pub recover_unknown_attributes: bool,
 }
 
 #[derive(Debug)]
@@ -182,6 +185,8 @@ impl FrameDecoder<'_, '_> {
         new_actors: &mut Vec<NewActor>,
         deleted_actors: &mut Vec<ActorId>,
         updated_actors: &mut Vec<UpdatedAttribute>,
+        warnings: &mut Vec<NetworkWarning>,
+        frame_index: usize,
     ) -> Result<DecodedFrame, FrameError> {
         let time = bits
             .read_f32()
@@ -265,40 +270,26 @@ impl FrameDecoder<'_, '_> {
                         );
                         let stream_id = StreamId(stream_id_raw as i32);
 
-                        // Look the stream id up and find the corresponding attribute
-                        // decoding function. Experience has told me replays that fail to
-                        // parse, fail to do so here, so a large chunk is dedicated to
-                        // generating an error message with context
-                        let attr = cache_info.attributes.get(stream_id).ok_or(
-                            FrameError::MissingAttribute {
-                                actor: actor_id,
-                                actor_object: *object_id,
-                                attribute_stream: stream_id,
-                            },
-                        )?;
-
-                        let attribute = attr_decoder.decode(attr.attribute, bits, buf).map_err(
-                            |e| match e {
-                                AttributeError::Unimplemented => FrameError::MissingAttribute {
-                                    actor: actor_id,
-                                    actor_object: *object_id,
-                                    attribute_stream: stream_id,
-                                },
-                                e => FrameError::AttributeError {
-                                    actor: actor_id,
-                                    actor_object: *object_id,
-                                    attribute_stream: stream_id,
-                                    error: e,
-                                },
-                            },
-                        )?;
-
-                        updated_actors.push(UpdatedAttribute {
+                        match recovery::decode_attribute_update(recovery::AttributeDecodeRequest {
+                            attr_decoder,
+                            bits,
+                            buf,
+                            cache_info,
+                            objects: &self.body.objects,
                             actor_id,
+                            actor_object_id: *object_id,
                             stream_id,
-                            object_id: attr.object_id,
-                            attribute,
-                        });
+                            frame_index,
+                            recover_unknown_attributes: self.recover_unknown_attributes,
+                        })? {
+                            AttributeDecodeResult::Decoded(attribute) => {
+                                updated_actors.push(attribute);
+                            }
+                            AttributeDecodeResult::Recovered(warning) => {
+                                warnings.push(warning);
+                                continue;
+                            }
+                        }
                     }
                 }
             } else {
@@ -343,7 +334,7 @@ impl FrameDecoder<'_, '_> {
         }))
     }
 
-    pub fn decode_frames(&self) -> Result<Vec<Frame>, NetworkError> {
+    pub fn decode_frames(&self) -> Result<(Vec<Frame>, Vec<NetworkWarning>), NetworkError> {
         let attr_decoder = AttributeDecoder {
             version: self.version,
             product_decoder: self.product_decoder,
@@ -356,6 +347,7 @@ impl FrameDecoder<'_, '_> {
         let mut new_actors = Vec::new();
         let mut updated_actors = Vec::new();
         let mut deleted_actors = Vec::new();
+        let mut warnings = Vec::new();
         let mut buf = [0u8; 1024];
 
         while !bits.is_empty() && frames.len() < self.frames_len {
@@ -368,6 +360,8 @@ impl FrameDecoder<'_, '_> {
                     &mut new_actors,
                     &mut deleted_actors,
                     &mut updated_actors,
+                    &mut warnings,
+                    frames.len(),
                 )
                 .map_err(|e| {
                     NetworkError::FrameError(
@@ -410,6 +404,6 @@ impl FrameDecoder<'_, '_> {
             let _ = bits.read_u32();
         }
 
-        Ok(frames)
+        Ok((frames, warnings))
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -6,6 +6,7 @@ pub mod attributes;
 mod frame_decoder;
 mod models;
 mod object_index;
+mod recovery;
 
 use crate::data::{ATTRIBUTES, SPAWN_STATS};
 use crate::errors::NetworkError;
@@ -40,6 +41,21 @@ impl VersionTriplet {
 }
 
 pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames, NetworkError> {
+    parse_with_recovery(header, body, false)
+}
+
+pub(crate) fn parse_best_effort(
+    header: &Header,
+    body: &ReplayBody,
+) -> Result<NetworkFrames, NetworkError> {
+    parse_with_recovery(header, body, true)
+}
+
+fn parse_with_recovery(
+    header: &Header,
+    body: &ReplayBody,
+    recover_unknown_attributes: bool,
+) -> Result<NetworkFrames, NetworkError> {
     let version = VersionTriplet(
         header.major_version,
         header.minor_version,
@@ -184,12 +200,18 @@ pub(crate) fn parse(header: &Header, body: &ReplayBody) -> Result<NetworkFrames,
             version,
             is_lan,
             is_rl_223,
+            recover_unknown_attributes,
         };
+        let (frames, network_warnings) = frame_decoder.decode_frames()?;
         Ok(NetworkFrames {
-            frames: frame_decoder.decode_frames()?,
+            frames,
+            network_warnings,
         })
     } else {
-        Ok(NetworkFrames { frames: Vec::new() })
+        Ok(NetworkFrames {
+            frames: Vec::new(),
+            network_warnings: Vec::new(),
+        })
     }
 }
 

--- a/src/network/models.rs
+++ b/src/network/models.rs
@@ -232,6 +232,25 @@ pub struct UpdatedAttribute {
     pub attribute: Attribute,
 }
 
+/// Describes a lossy recovery applied while decoding network frames.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NetworkWarning {
+    pub frame: usize,
+    pub actor_id: ActorId,
+    pub actor_object_id: ObjectId,
+    pub stream_id: StreamId,
+    pub attribute_object_id: Option<ObjectId>,
+    pub attribute_name: Option<String>,
+    pub recovery: RecoveryKind,
+}
+
+/// The speculative action used to continue decoding after an unknown attribute.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum RecoveryKind {
+    GuessedAttribute { decoder: &'static str },
+    SkippedBits { bits: u32 },
+}
+
 /// Contains the time and any new information that occurred during a frame
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Frame {

--- a/src/network/recovery.rs
+++ b/src/network/recovery.rs
@@ -1,0 +1,300 @@
+use bitter::{BitReader, LittleEndianReader};
+
+use crate::bits::RlBits;
+use crate::errors::{AttributeError, FrameError};
+use crate::network::attributes::{AttributeDecoder, AttributeTag};
+use crate::network::models::{
+    ActorId, NetworkWarning, ObjectId, RecoveryKind, StreamId, UpdatedAttribute,
+};
+use crate::network::CacheInfo;
+
+const MAX_SKIP_BITS: u32 = 64;
+
+pub(crate) enum AttributeDecodeResult {
+    Decoded(UpdatedAttribute),
+    Recovered(NetworkWarning),
+}
+
+pub(crate) struct AttributeDecodeRequest<'a, 'b> {
+    pub attr_decoder: &'a AttributeDecoder,
+    pub bits: &'a mut LittleEndianReader<'b>,
+    pub buf: &'a mut [u8],
+    pub cache_info: &'a CacheInfo,
+    pub objects: &'a [String],
+    pub actor_id: ActorId,
+    pub actor_object_id: ObjectId,
+    pub stream_id: StreamId,
+    pub frame_index: usize,
+    pub recover_unknown_attributes: bool,
+}
+
+pub(crate) fn decode_attribute_update(
+    req: AttributeDecodeRequest<'_, '_>,
+) -> Result<AttributeDecodeResult, FrameError> {
+    let attr = match req.cache_info.attributes.get(req.stream_id).copied() {
+        Some(attr) => attr,
+        None if req.recover_unknown_attributes => {
+            if let Some(recovery) =
+                recover_unknown_attribute(req.attr_decoder, req.bits, req.buf, req.cache_info, None)
+            {
+                return Ok(AttributeDecodeResult::Recovered(NetworkWarning {
+                    frame: req.frame_index,
+                    actor_id: req.actor_id,
+                    actor_object_id: req.actor_object_id,
+                    stream_id: req.stream_id,
+                    attribute_object_id: None,
+                    attribute_name: None,
+                    recovery,
+                }));
+            }
+
+            return Err(missing_attribute_error(&req));
+        }
+        None => return Err(missing_attribute_error(&req)),
+    };
+
+    if req.recover_unknown_attributes && attr.attribute == AttributeTag::NotImplemented {
+        let attribute_name = req
+            .objects
+            .get(usize::from(attr.object_id))
+            .map(String::as_str);
+
+        if let Some(recovery) = recover_unknown_attribute(
+            req.attr_decoder,
+            req.bits,
+            req.buf,
+            req.cache_info,
+            attribute_name,
+        ) {
+            return Ok(AttributeDecodeResult::Recovered(NetworkWarning {
+                frame: req.frame_index,
+                actor_id: req.actor_id,
+                actor_object_id: req.actor_object_id,
+                stream_id: req.stream_id,
+                attribute_object_id: Some(attr.object_id),
+                attribute_name: attribute_name.map(String::from),
+                recovery,
+            }));
+        }
+
+        return Err(missing_attribute_error(&req));
+    }
+
+    let attribute = req
+        .attr_decoder
+        .decode(attr.attribute, req.bits, req.buf)
+        .map_err(|e| match e {
+            AttributeError::Unimplemented => missing_attribute_error(&req),
+            e => FrameError::AttributeError {
+                actor: req.actor_id,
+                actor_object: req.actor_object_id,
+                attribute_stream: req.stream_id,
+                error: e,
+            },
+        })?;
+
+    Ok(AttributeDecodeResult::Decoded(UpdatedAttribute {
+        actor_id: req.actor_id,
+        stream_id: req.stream_id,
+        object_id: attr.object_id,
+        attribute,
+    }))
+}
+
+fn missing_attribute_error(req: &AttributeDecodeRequest<'_, '_>) -> FrameError {
+    FrameError::MissingAttribute {
+        actor: req.actor_id,
+        actor_object: req.actor_object_id,
+        attribute_stream: req.stream_id,
+    }
+}
+
+fn recover_unknown_attribute(
+    attr_decoder: &AttributeDecoder,
+    bits: &mut LittleEndianReader<'_>,
+    buf: &mut [u8],
+    cache_info: &CacheInfo,
+    attribute_name: Option<&str>,
+) -> Option<RecoveryKind> {
+    for candidate in candidates(attribute_name) {
+        let mut trial = *bits;
+        if attr_decoder.decode(candidate.tag, &mut trial, buf).is_ok()
+            && looks_aligned(trial, cache_info)
+        {
+            *bits = trial;
+            return Some(RecoveryKind::GuessedAttribute {
+                decoder: candidate.name,
+            });
+        }
+    }
+
+    // Last resort: consume a small bounded number of bits and keep the first
+    // locally plausible alignment. This is intentionally narrow because there
+    // is no generic length prefix for network attributes.
+    for skipped in 1..=MAX_SKIP_BITS {
+        let mut trial = *bits;
+        trial.read_bits(skipped)?;
+        if looks_aligned(trial, cache_info) {
+            *bits = trial;
+            return Some(RecoveryKind::SkippedBits { bits: skipped });
+        }
+    }
+
+    None
+}
+
+fn looks_aligned(mut bits: LittleEndianReader<'_>, cache_info: &CacheInfo) -> bool {
+    let Some(has_next_attr) = bits.read_bit() else {
+        return false;
+    };
+
+    if !has_next_attr {
+        return true;
+    }
+
+    bits.refill_lookahead();
+    if bits.lookahead_bits() < cache_info.prop_id_bits + 1 {
+        return false;
+    }
+
+    let stream_id = StreamId(
+        bits.peek_bits_max_computed(cache_info.prop_id_bits, u64::from(cache_info.max_prop_id))
+            as i32,
+    );
+    cache_info.attributes.get(stream_id).is_some()
+}
+
+#[derive(Clone, Copy)]
+struct Candidate {
+    name: &'static str,
+    tag: AttributeTag,
+}
+
+fn candidates(attribute_name: Option<&str>) -> Vec<Candidate> {
+    let mut candidates = Vec::with_capacity(10);
+    if let Some(name) = attribute_name {
+        add_name_candidates(name, &mut candidates);
+    }
+
+    for candidate in [
+        Candidate {
+            name: "boolean",
+            tag: AttributeTag::Boolean,
+        },
+        Candidate {
+            name: "byte",
+            tag: AttributeTag::Byte,
+        },
+        Candidate {
+            name: "int",
+            tag: AttributeTag::Int,
+        },
+        Candidate {
+            name: "float",
+            tag: AttributeTag::Float,
+        },
+        Candidate {
+            name: "active_actor",
+            tag: AttributeTag::ActiveActor,
+        },
+        Candidate {
+            name: "rigid_body",
+            tag: AttributeTag::RigidBody,
+        },
+        Candidate {
+            name: "string",
+            tag: AttributeTag::String,
+        },
+    ] {
+        push_unique(&mut candidates, candidate);
+    }
+
+    candidates
+}
+
+fn add_name_candidates(name: &str, candidates: &mut Vec<Candidate>) {
+    let property = name
+        .rsplit_once(':')
+        .map(|(_, property)| property)
+        .unwrap_or(name)
+        .to_ascii_lowercase();
+
+    if property.starts_with('b') {
+        push_unique(
+            candidates,
+            Candidate {
+                name: "boolean",
+                tag: AttributeTag::Boolean,
+            },
+        );
+    }
+
+    if property.contains("name") || property.contains("title") || property.contains("text") {
+        push_unique(
+            candidates,
+            Candidate {
+                name: "string",
+                tag: AttributeTag::String,
+            },
+        );
+    }
+
+    if property.contains("rbstate")
+        || property.contains("rigid")
+        || property.contains("location")
+        || property.contains("velocity")
+    {
+        push_unique(
+            candidates,
+            Candidate {
+                name: "rigid_body",
+                tag: AttributeTag::RigidBody,
+            },
+        );
+    }
+
+    if property.contains("actor") || property.contains("owner") || property.contains("pri") {
+        push_unique(
+            candidates,
+            Candidate {
+                name: "active_actor",
+                tag: AttributeTag::ActiveActor,
+            },
+        );
+    }
+
+    if property.contains("ping")
+        || property.contains("team")
+        || property.contains("platform")
+        || property.contains("byte")
+    {
+        push_unique(
+            candidates,
+            Candidate {
+                name: "byte",
+                tag: AttributeTag::Byte,
+            },
+        );
+    }
+
+    if property.contains("score")
+        || property.contains("count")
+        || property.contains("num")
+        || property.contains("index")
+        || property.ends_with("id")
+    {
+        push_unique(
+            candidates,
+            Candidate {
+                name: "int",
+                tag: AttributeTag::Int,
+            },
+        );
+    }
+}
+
+fn push_unique(candidates: &mut Vec<Candidate>, candidate: Candidate) {
+    if !candidates.iter().any(|x| x.tag == candidate.tag) {
+        candidates.push(candidate);
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -265,6 +265,7 @@ pub struct ParserBuilder<'a> {
     data: &'a [u8],
     crc_check: Option<CrcCheck>,
     network_parse: Option<NetworkParse>,
+    recover_unknown_network_attributes: bool,
 }
 
 impl<'a> ParserBuilder<'a> {
@@ -273,6 +274,7 @@ impl<'a> ParserBuilder<'a> {
             data,
             crc_check: None,
             network_parse: None,
+            recover_unknown_network_attributes: false,
         }
     }
 
@@ -311,6 +313,12 @@ impl<'a> ParserBuilder<'a> {
         self
     }
 
+    pub fn best_effort_network_data(mut self) -> ParserBuilder<'a> {
+        self.network_parse = Some(NetworkParse::Always);
+        self.recover_unknown_network_attributes = true;
+        self
+    }
+
     pub fn with_network_parse(mut self, parse: NetworkParse) -> ParserBuilder<'a> {
         self.network_parse = Some(parse);
         self
@@ -322,6 +330,7 @@ impl<'a> ParserBuilder<'a> {
             self.crc_check.unwrap_or(CrcCheck::OnError),
             self.network_parse.unwrap_or(NetworkParse::IgnoreOnError),
         );
+        parser.recover_unknown_network_attributes = self.recover_unknown_network_attributes;
         parser.parse()
     }
 }
@@ -347,6 +356,7 @@ pub struct Parser<'a> {
     core: CoreParser<'a>,
     crc_check: CrcCheck,
     network_parse: NetworkParse,
+    recover_unknown_network_attributes: bool,
 }
 
 impl<'a> Parser<'a> {
@@ -355,6 +365,7 @@ impl<'a> Parser<'a> {
             core: CoreParser::new(data),
             crc_check,
             network_parse,
+            recover_unknown_network_attributes: false,
         }
     }
 
@@ -378,6 +389,10 @@ impl<'a> Parser<'a> {
         let body = self.crc_section(content_data, content_crc, "body", Self::parse_body)?;
 
         let network: Option<NetworkFrames> = match self.network_parse {
+            NetworkParse::Always if self.recover_unknown_network_attributes => Some(
+                self.parse_network_best_effort(&header, &body)
+                    .map_err(|x| ParseError::NetworkError(Box::new(x)))?,
+            ),
             NetworkParse::Always => Some(
                 self.parse_network(&header, &body)
                     .map_err(|x| ParseError::NetworkError(Box::new(x)))?,
@@ -418,6 +433,14 @@ impl<'a> Parser<'a> {
         body: &ReplayBody<'_>,
     ) -> Result<NetworkFrames, NetworkError> {
         network::parse(header, body)
+    }
+
+    fn parse_network_best_effort(
+        &mut self,
+        header: &Header,
+        body: &ReplayBody<'_>,
+    ) -> Result<NetworkFrames, NetworkError> {
+        network::parse_best_effort(header, body)
     }
 
     fn parse_header(&mut self) -> Result<Header, ParseError> {
@@ -689,6 +712,26 @@ mod tests {
         let mut parser = Parser::new(&data[..], CrcCheck::Never, NetworkParse::Always);
         let err = parser.parse().unwrap_err();
         assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn test_best_effort_is_opt_in_and_quiet_for_known_replays() {
+        let data = include_bytes!("../assets/replays/good/rumble.replay");
+        let strict = ParserBuilder::new(&data[..])
+            .never_check_crc()
+            .must_parse_network_data()
+            .parse()
+            .unwrap();
+        let best_effort = ParserBuilder::new(&data[..])
+            .never_check_crc()
+            .best_effort_network_data()
+            .parse()
+            .unwrap();
+
+        let strict_frames = strict.network_frames.unwrap();
+        let best_effort_frames = best_effort.network_frames.unwrap();
+        assert_eq!(strict_frames.frames.len(), best_effort_frames.frames.len());
+        assert!(best_effort_frames.network_warnings.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit `best_effort_network_data()` parser builder path for speculative network-frame recovery
- keep the normal strict/default network parsing paths unchanged
- record lossy recovery actions in `NetworkFrames::network_warnings` while omitting recovered unknown attributes from frame updates
- isolate the guessing logic in `src/network/recovery.rs` with bounded decoder attempts and bit-skip recovery

## Validation

- `cargo check`
- `cargo fmt --check`
- `git diff --check --cached` before commit

Full tests were not run locally because the current Rust toolchain is 1.88.0 and the dev-dependency path through `gungraun -> bincode-next -> unty-next@0.1.1` now requires Rust 1.90.
